### PR TITLE
stream.xlsx.WorkBookReader - Fixed issue that prevented 'shared-string' event being emitted when "emit" selected in options

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -158,7 +158,6 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
         var inT = false;
         var t = null;
         var index = 0;
-        var sharedStrings = [];
         parser.on('opentag', function(node) {
             if (node.name == "t") {
                 t = null;


### PR DESCRIPTION
sharedStrings initialized a second time by mistake. When "emit" option is selected, logic expects sharedStrings to still be null, not initialized to empty array. The result is that event never gets emitted.