### PR TITLE
Promise.defer() replaced by new Promise(function(resolve, reject)

### DIFF
--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -58,19 +58,21 @@ CSV.prototype = {
     },
     read: function(stream, options) {
         options = options || {};
-        var deferred = Promise.defer();
-        
-        var csvStream = this.createInputStream(options)
-            .on("worksheet", function(worksheet) {
-                deferred.resolve(worksheet);
-            })
-            .on("error", function(error) {
-                deferred.reject(error);
-            });
-        
-        stream.pipe(csvStream);
-        
-        return deferred.promise;
+        var self = this;
+        return new Promise(function(resolve, reject) {
+           
+            var csvStream = self.createInputStream(options)
+                .on("worksheet", function(worksheet) {
+                    resolve(worksheet);
+                })
+                .on("error", function(error) {
+                    reject(error);
+                });
+            
+            stream.pipe(csvStream);
+            
+        });
+
     },
     createInputStream: function(options) {
         options = options || {};
@@ -106,55 +108,58 @@ CSV.prototype = {
     },
     
     write: function(stream, options) {
-        var deferred = Promise.defer();
+
+        var self = this;
         
-        options = options || {};
-        //var encoding = options.encoding || "utf8";
-        //var separator = options.separator || ',';
-        //var quoteChar = options.quoteChar || '"';
-        
-        var worksheet = this.workbook.getWorksheet(options.sheetName || options.sheetId)
-        
-        var csvStream = csv.createWriteStream(options);
-        stream.on("finish", function() {
-            deferred.resolve();
+        return new Promise(function(resolve, reject) {
+            options = options || {};
+            //var encoding = options.encoding || "utf8";
+            //var separator = options.separator || ',';
+            //var quoteChar = options.quoteChar || '"';
+            
+            var worksheet = self.workbook.getWorksheet(options.sheetName || options.sheetId)
+            
+            var csvStream = csv.createWriteStream(options);
+            stream.on("finish", function() {
+                resolve();
+            });
+            csvStream.on("error", function(error) {
+                reject(error);
+            });
+            csvStream.pipe(stream);
+            
+            var dateFormat = options.dateFormat;
+            var map = options.map || function(value) {
+                if (value) {
+                    if (value.text || value.hyperlink) {
+                        return value.hyperlink || value.text || "";
+                    }
+                    if (value.formula || value.result) {
+                        return value.result || "";
+                    }
+                    if (value instanceof Date) {
+                        return dateFormat ? moment(value).format(dateFormat) : moment(value).format();
+                    }
+                }
+                return value;
+            };
+            
+            var includeEmptyRows = (options.includeEmptyRows === undefined) || options.includeEmptyRows;
+            var lastRow = 1;
+            worksheet.eachRow(function(row, rowNumber) {
+                if (includeEmptyRows) {
+                    while (lastRow++ < rowNumber-1) {
+                        csvStream.write([]);
+                    }
+                }
+                var values = row.values;
+                values.shift();
+                csvStream.write(values.map(map));
+                lastRow = rowNumber;
+            });
+            csvStream.end();
         });
-        csvStream.on("error", function(error) {
-            deferred.reject(error);
-        });
-        csvStream.pipe(stream);
         
-        var dateFormat = options.dateFormat;
-        var map = options.map || function(value) {
-            if (value) {
-                if (value.text || value.hyperlink) {
-                    return value.hyperlink || value.text || "";
-                }
-                if (value.formula || value.result) {
-                    return value.result || "";
-                }
-                if (value instanceof Date) {
-                    return dateFormat ? moment(value).format(dateFormat) : moment(value).format();
-                }
-            }
-            return value;
-        };
-        
-        var includeEmptyRows = (options.includeEmptyRows === undefined) || options.includeEmptyRows;
-        var lastRow = 1;
-        worksheet.eachRow(function(row, rowNumber) {
-            if (includeEmptyRows) {
-                while (lastRow++ < rowNumber-1) {
-                    csvStream.write([]);
-                }
-            }
-            var values = row.values;
-            values.shift();
-            csvStream.write(values.map(map));
-            lastRow = rowNumber;
-        });
-        csvStream.end();
-        return deferred.promise;
     },
     writeFile: function(filename, options) {
         options = options || {};

--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -82,14 +82,17 @@ WorkbookWriter.prototype = {
         return stream;
     },
     _commitWorksheets: function() {
+
         var commitWorksheet = function(worksheet) {
             if (!worksheet.committed) {
-                var deferred = Promise.defer();
-                worksheet.stream.on('zipped', function() {
-                    deferred.resolve();
+
+                return new Promise(function(resolve, reject) {
+                    worksheet.stream.on('zipped', function() {
+                        resolve();
+                    });
+                    worksheet.commit();    
                 });
-                worksheet.commit();    
-                return deferred.promise;
+        
             } else {
                 return Promise.resolve();
             }
@@ -287,21 +290,20 @@ WorkbookWriter.prototype = {
     },
     _finalize: function() {
         var self = this;
-        var deferred = Promise.defer();
-        
-        this.stream.on('error', function(error){
-            deferred.reject(error);
+      
+        return new Promise(function(resolve, reject) {
+            self.stream.on('error', function(error){
+                reject(error);
+            });
+            self.stream.on('finish', function(){
+                resolve(self);
+            });
+            self.zip.on('error', function(error){
+                reject(error);
+            });
+            
+            self.zip.finalize();
         });
-        this.stream.on('finish', function(){
-            deferred.resolve(self);
-        });
-        this.zip.on('error', function(error){
-            deferred.reject(error);
-        });
-        
-        this.zip.finalize();
-        
-        return deferred.promise;
     }
 };
 

--- a/lib/utils/flow-control.js
+++ b/lib/utils/flow-control.js
@@ -90,19 +90,20 @@ utils.inherits(FlowControl, events.EventEmitter, {
     
     _write: function(dst, data, encoding) {
         var self = this;
-        // Write to a single destination and return a promise
-        var deferred = Promise.defer();
+        // Write to a single destination and return a promise    
         // console.log(this.name + " _write: " + data.length);
-        dst.write(data, encoding, function(error) {
-            if (error) {
-                // console.log(self.name + " _write error: " + error.message);            
-                deferred.reject(error);
-            } else {
-                // console.log(self.name + " _write complete");            
-                deferred.resolve();
-            }
+
+        return new Promise(function(resolve, reject) {
+           dst.write(data, encoding, function(error) {
+                if (error) {
+                    // console.log(self.name + " _write error: " + error.message);            
+                    reject(error);
+                } else {
+                    // console.log(self.name + " _write complete");            
+                    resolve();
+                }
+            });
         });
-        return deferred.promise;
     },
     
     _pipe: function(chunk) {
@@ -145,14 +146,15 @@ utils.inherits(FlowControl, events.EventEmitter, {
     _delay: function() {
         // in certain situations it may be useful to delay processing (e.g. for GC)
         var timeout = this.getTimeout && this.getTimeout();
+        var self = this;
         if (timeout) {
-            var deferred = Promise.defer();
-            var anime = this._animate();
-            setTimeout(function() {
-                clearInterval(anime);
-                deferred.resolve();
-            }, timeout);
-            return deferred.promise;
+           return new Promise(function(resolve, reject) {
+                var anime = self._animate();
+                setTimeout(function() {
+                    clearInterval(anime);
+                    resolve();
+                }, timeout);
+            });
         } else {
             return Promise.resolve();
         }

--- a/lib/utils/stream-buf.js
+++ b/lib/utils/stream-buf.js
@@ -191,11 +191,11 @@ utils.inherits(StreamBuf, Stream.Duplex, {
     
     _pipe: function(chunk) {
         var write = function(pipe) {
-            var deferred = Promise.defer();
-            pipe.write(chunk.toBuffer(), function() {
-                deferred.resolve();
-            });
-            return deferred.promise;
+            return new Promise(function(resolve, reject) {
+                pipe.write(chunk.toBuffer(), function() {
+                    resolve();
+                });
+            });    
         }
         var promises = this.pipes.map(write);
         return promises.length ?

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -32,15 +32,15 @@ var moduleFile = {
     read: function(path) {
         // if not already load-ed-ing...
         if (!this.cache[path]) {
-            var deferred = Promise.defer();
-            fs.readFile(path, 'utf8', function(error, data) {
-                if (error) {
-                    deferred.reject(err);
-                } else {
-                    deferred.resolve(data);
-                }
+            this.cache[path] = new Promise(function(resolve, reject) {
+               fs.readFile(path, 'utf8', function(error, data) {
+                    if (error) {
+                        reject(err);
+                    } else {
+                        resolve(data);
+                    }
+                });
             });
-            this.cache[path] = deferred.promise;
         }
         return this.cache[path];
     }
@@ -97,18 +97,19 @@ var inherits = function(cls, superCtor, statics, prototype) {
 var utils = module.exports = {
     nop: function() {},
     promiseImmediate: function(value) {
-        var deferred = Promise.defer();
-        if (global.setImmediate) {
-            setImmediate(function() {
-                deferred.resolve(value);
-            });
-        } else {
-            // poorman's setImmediate - must wait at least 1ms
-            setTimeout(function() {
-                deferred.resolve(value);
-            },1);
-        }
-        return deferred.promise;
+        return new Promise(function(resolve, reject) {
+            if (global.setImmediate) {
+                setImmediate(function() {
+                    resolve(value);
+                });
+            } else {
+                // poorman's setImmediate - must wait at least 1ms
+                setTimeout(function() {
+                    resolve(value);
+                },1);
+            }
+        });
+        
     },
     readModuleFile: function(path) {
         return moduleFile.read(path);
@@ -176,11 +177,12 @@ var utils = module.exports = {
 
     fs: {
         exists: function(path) {
-            var deferred = Promise.defer();
-            fs.exists(path, function(exists) {
-                deferred.resolve(exists);
+            return new Promise(function(resolve, reject) {
+
+                fs.exists(path, function(exists) {
+                    resolve(exists);
+                });   
             });
-            return deferred.promise;
         }
     }
 };

--- a/lib/xlsx/stylemanager.js
+++ b/lib/xlsx/stylemanager.js
@@ -100,7 +100,6 @@ utils.inherits(StyleManager, events.EventEmitter, {
     // parse the styles.xml file pulling out fonts, numFmts, etc
     parse: function(stream) {
         var self = this;
-        var deferred = Promise.defer();
         var parser = Sax.createStream(true, {});
         
         var inNumFmts = false;
@@ -113,116 +112,120 @@ utils.inherits(StyleManager, events.EventEmitter, {
         var font = null;
         var border = null;
         var fill = null;
+
+        return new Promise(function(resolve, reject) {
+   
         
-        parser.on('opentag', function(node) {
-            if (inNumFmts) {
-                if (node.name == "numFmt") {
-                    var numFmt = new NumFmt();
-                    numFmt.parse(node);
-                    self._addNumFmt(numFmt);
+            parser.on('opentag', function(node) {
+                if (inNumFmts) {
+                    if (node.name == "numFmt") {
+                        var numFmt = new NumFmt();
+                        numFmt.parse(node);
+                        self._addNumFmt(numFmt);
+                    }
+                } else if (inCellXfs) {
+                    if (style) {
+                        style.parse(node);
+                    } else if (node.name == "xf") {
+                        style = new Style();
+                        style.parse(node);
+                    }
+                } else if (inFonts) {
+                    if (font) {
+                        font.parse(node);
+                    } else if (node.name == "font") {
+                        font = new Font();
+                    }
+                } else if (inBorders) {
+                    if (node.name == "border") {
+                        border = new Border();
+                    }
+                    border.parse(node);
+                } else if (inFills) {
+                    if (node.name == "fill") {
+                        fill = new Fill();
+                    }
+                    fill.parse(node);
+                } else {
+                    switch(node.name) {
+                        case 'cellXfs':
+                            inCellXfs = true;
+                            break;
+                        case 'numFmts':
+                            inNumFmts = true;
+                            break;
+                        case 'fonts':
+                            inFonts = true;
+                            break;
+                        case 'borders':
+                            inBorders = true;
+                            break;
+                        case 'fills':
+                            inFills = true;
+                            break;
+                    }
                 }
-            } else if (inCellXfs) {
-                if (style) {
-                    style.parse(node);
-                } else if (node.name == "xf") {
-                    style = new Style();
-                    style.parse(node);
+            });
+            parser.on('closetag', function (name) {
+                if (inCellXfs) {
+                    switch(name) {
+                        case 'cellXfs':
+                            inCellXfs = false;
+                            break;
+                        case 'xf':
+                            self._addStyle(style);
+                            style = null;
+                            break;
+                    }
+                } else if (inNumFmts) {
+                    switch(name) {
+                        case 'numFmts':
+                            inNumFmts = false;
+                            break;
+                    }
+                } else if (inFonts) {
+                    switch(name) {
+                        case 'fonts':
+                            inFonts = false;
+                            break;
+                        case 'font':
+                            self._addFont(font);
+                            font = null;
+                            break;
+                    }
+                } else if (inBorders) {
+                    switch(name) {
+                        case 'borders':
+                            inBorders = false;
+                            break;
+                        case 'border':
+                            self._addBorder(border);
+                            border = null;
+                            break;
+                    }
+                } else if (inFills) {
+                    switch(name) {
+                        case 'fills':
+                            inFills = false;
+                            break;
+                        case 'fill':
+                            self._addFill(fill);
+                            fill = null;
+                            break;
+                    }
                 }
-            } else if (inFonts) {
-                if (font) {
-                    font.parse(node);
-                } else if (node.name == "font") {
-                    font = new Font();
-                }
-            } else if (inBorders) {
-                if (node.name == "border") {
-                    border = new Border();
-                }
-                border.parse(node);
-            } else if (inFills) {
-                if (node.name == "fill") {
-                    fill = new Fill();
-                }
-                fill.parse(node);
-            } else {
-                switch(node.name) {
-                    case 'cellXfs':
-                        inCellXfs = true;
-                        break;
-                    case 'numFmts':
-                        inNumFmts = true;
-                        break;
-                    case 'fonts':
-                        inFonts = true;
-                        break;
-                    case 'borders':
-                        inBorders = true;
-                        break;
-                    case 'fills':
-                        inFills = true;
-                        break;
-                }
-            }
-        });
-        parser.on('closetag', function (name) {
-            if (inCellXfs) {
-                switch(name) {
-                    case 'cellXfs':
-                        inCellXfs = false;
-                        break;
-                    case 'xf':
-                        self._addStyle(style);
-                        style = null;
-                        break;
-                }
-            } else if (inNumFmts) {
-                switch(name) {
-                    case 'numFmts':
-                        inNumFmts = false;
-                        break;
-                }
-            } else if (inFonts) {
-                switch(name) {
-                    case 'fonts':
-                        inFonts = false;
-                        break;
-                    case 'font':
-                        self._addFont(font);
-                        font = null;
-                        break;
-                }
-            } else if (inBorders) {
-                switch(name) {
-                    case 'borders':
-                        inBorders = false;
-                        break;
-                    case 'border':
-                        self._addBorder(border);
-                        border = null;
-                        break;
-                }
-            } else if (inFills) {
-                switch(name) {
-                    case 'fills':
-                        inFills = false;
-                        break;
-                    case 'fill':
-                        self._addFill(fill);
-                        fill = null;
-                        break;
-                }
-            }
-        });
-        parser.on('end', function() {
-            // warning: if style, font, border, fill, inBorders, inFills, inFonts, inCellXfs, inNumFmts are true!
-            deferred.resolve(self);
-        });
-        parser.on('error', function (error) {
-            deferred.reject(error);
-        });
-        stream.pipe(parser);
+            });
+            parser.on('end', function() {
+                // warning: if style, font, border, fill, inBorders, inFills, inFonts, inCellXfs, inNumFmts are true!
+                resolve(self);
+            });
+            parser.on('error', function (error) {
+                reject(null,error);
+            });
+            stream.pipe(parser);
         
-        return deferred.promise;
+       
+        });
     },
     
     // add a cell's style model to the collection

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -377,7 +377,7 @@ XLSX.prototype = {
       });
   },
   parseRels: function (stream) {
-    var deferred = Promise.defer();
+    
 
     var relationships = {};
 
@@ -444,19 +444,21 @@ XLSX.prototype = {
         }
       }
     });
-    parser.on("end", function () {
-      deferred.resolve(relationships);
-    });
-    parser.on("error", function (error) {
-      deferred.reject(error);
-    });
 
-    stream.pipe(parser);
+    return new Promise(function(resolve, reject) {
+      
+        parser.on("end", function () {
+          resolve(relationships);
+        });
+        parser.on("error", function (error) {
+          reject(error);
+        });
 
-    return deferred.promise;
+        stream.pipe(parser); 
+    });
+  
   },
   parseWorkbook: function (stream) {
-    var deferred = Promise.defer();
     var self = this;
     var parser = Sax.createStream(true, {});
     var sheetDefs = {};
@@ -474,18 +476,20 @@ XLSX.prototype = {
         };
       }
     });
-    parser.on('end', function () {
-      deferred.resolve(sheetDefs);
-    });
-    parser.on('error', function (error) {
-      deferred.reject(error);
-    });
-    stream.pipe(parser);
 
-    return deferred.promise;
+    return new Promise(function(resolve, reject) {
+   
+      parser.on('end', function () {
+        resolve(sheetDefs);
+      });
+      parser.on('error', function (error) {
+        reject(error);
+      });
+      stream.pipe(parser);
+    });
+  
   },
   parseSharedStrings: function (stream) {
-    var deferred = Promise.defer();
     var parser = Sax.createStream(true, {});
     var t = null;
     var sharedStrings = [];
@@ -505,22 +509,25 @@ XLSX.prototype = {
         t += text;
       }
     });
-    parser.on('end', function () {
-      deferred.resolve(sharedStrings);
-    });
-    parser.on('error', function (error) {
-      deferred.reject(error);
-    });
-    stream.pipe(parser);
 
-    return deferred.promise;
+    return new Promise(function(resolve, reject) {
+   
+        parser.on('end', function () {
+          resolve(sharedStrings);
+        });
+        parser.on('error', function (error) {
+          reject(error);
+        });
+        stream.pipe(parser);
+    });
+   
+
   },
   parseWorksheet: function (stream) {
     // <cols><col min="1" max="1" width="25" style="?" />
     // <sheetData><row><c r="A1" s="1" t="s"><f>A2</f><v>value</v></c>
     // <mergeCells><mergeCell ref="A1:B2" />
     // <hyperlinks><hyperlink ref="A1" r:id="rId1" />
-    var deferred = Promise.defer();
 
     var parser = Sax.createStream(true, {});
 
@@ -640,20 +647,23 @@ XLSX.prototype = {
           break;
       }
     });
-    parser.on('end', function () {
-      // if cols empty then can remove it from model
-      if (!model.cols.length) {
-        delete model.cols;
-      }
 
-      deferred.resolve(model);
-    });
-    parser.on('error', function (error) {
-      deferred.reject(error);
-    });
-    stream.pipe(parser);
+    return new Promise(function(resolve, reject) {
+   
+        parser.on('end', function () {
+          // if cols empty then can remove it from model
+          if (!model.cols.length) {
+            delete model.cols;
+          }
 
-    return deferred.promise;
+          resolve(model);
+        });
+        parser.on('error', function (error) {
+          reject(error);
+        });
+        stream.pipe(parser);
+    });
+   
   },
   prepareModel: function (model) {
     // reconcile sheet ids, rIds and names
@@ -866,16 +876,18 @@ XLSX.prototype = {
   },
 
   read: function (stream) {
-    var deferred = Promise.defer();
     var self = this;
     var zipStream = this.createInputStream();
-    zipStream.on("done", function () {
-      deferred.resolve(self.workbook);
-    }).on("error", function (error) {
-      deferred.reject(error);
+
+    return new Promise(function(resolve, reject) {
+   
+      zipStream.on("done", function () {
+        resolve(self.workbook);
+      }).on("error", function (error) {
+        reject(error);
+      });
+      stream.pipe(zipStream);
     });
-    stream.pipe(zipStream);
-    return deferred.promise;
   },
 
   // =========================================================================
@@ -1166,18 +1178,20 @@ XLSX.prototype = {
   },
   _finalize: function (zip) {
     var self = this;
-    var deferred = Promise.defer();
 
-    zip.on('end', function () {
-      deferred.resolve(self);
+    return new Promise(function(resolve, reject) {
+
+      zip.on('end', function () {
+        resolve(self);
+      });
+      zip.on('error', function (error) {
+        reject(error);
+      });
+
+      zip.finalize();
+
     });
-    zip.on('error', function (error) {
-      deferred.reject(error);
-    });
 
-    zip.finalize();
-
-    return deferred.promise;
   },
   write: function (stream, options) {
     options = options || {};
@@ -1232,26 +1246,30 @@ XLSX.prototype = {
         return self._finalize(zip);
       });
   },
-  writeFile: function (filename, options) {
-    var deferred = Promise.defer();
+  writeFile: function (filename, options) {    
 
+    var self = this;
     var stream = fs.createWriteStream(filename);
 
-    stream.on("finish", function () {
-      deferred.resolve();
-    });
-    stream.on("error", function (error) {
-      deferred.reject(error);
-    });
-
-    this.write(stream, options)
-      .then(function () {
-        stream.end();
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+    return new Promise(function(resolve, reject) {
+   
+    
+      stream.on("finish", function () {
+        resolve();
+      });
+      stream.on("error", function (error) {
+        reject(error);
       });
 
-    return deferred.promise;
+      self.write(stream, options)
+        .then(function () {
+          stream.end();
+        })
+        .catch(function (error) {
+          reject(error);
+        });
+
+    });
+
   }
 }


### PR DESCRIPTION
For this issue #48 

Promise.defer() is not part of the Promise API anymore:

https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Deferred

```javascript
var deferred = Promise.defer();
doSomething(function cb(err, res) {
    if (err) deferred.reject(err); else deferred.resolve(res);
});
return deferred.promise;
```

is now replaced to 

```javascript
return new Promise(function(resolve, reject) {
    doSomething(function cb(err, res) {
        if (err) reject(err); else resolve(res);
    });
});
```