### PR TITLE
Fix TypeError crash

### DIFF
--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -659,6 +659,10 @@ XLSX.prototype = {
     // reconcile sheet ids, rIds and names
     _.each(model.sheetDefs, function (sheetDef) {
       var rel = model.workbookRels[sheetDef.rId];
+      if (!rel) {
+        return;
+      }
+
       var worksheet = model.worksheetHash["xl/" + rel.target];
       worksheet.name = sheetDef.name;
       worksheet.id = sheetDef.id;


### PR DESCRIPTION
I encountered the following:

```
Unhandled rejection TypeError: Cannot read property 'target' of undefined
    at .../node_modules/exceljs/lib/xlsx/xlsx.js:662:54
```

I traced this down to the fact that my Excel file contains a "chart sheet", which is missing from `model.workbookRels`. This guard allows the rest of the Excel file to be read.