### PR TITLE
Improve workbook.commit() example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,7 +857,9 @@ To complete the XLSX document, the workbook must be committed. If any worksheet 
 
 ```javascript
 // Finished the workbook.
-workbook.commit();
+workbook.commit().then(function() {
+  // the stream has been written
+});
 ```
 
 # Value Types


### PR DESCRIPTION
The `commit()` method in case of Workbook returns a promise. The example in README now reflects that.