### PR TITLE
some logs not commented out

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -95,7 +95,7 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
     var zip = this.zip = unzip.Parse();
 
     zip.on('entry',function (entry) {
-      console.log(entry.path)
+      // console.log(entry.path)
       var match, sheetNo;
       switch(entry.path) {
         case '_rels/.rels':
@@ -125,7 +125,7 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
       }
     });
     zip.on('finished', function() {
-        console.log('on close')
+        // console.log('on close')
         self.emit('end');
         self.atEnd = true;
         if (!self.readers) {
@@ -224,7 +224,7 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
   _parseWorksheet: function(entry, sheetNo, options) {
     this._emitEntry(options, {type: 'worksheet', id: sheetNo});
     var worksheetReader = this._getReader(WorksheetReader, this.worksheetReaders, sheetNo);
-    console.log('found worksheet', sheetNo)
+    // console.log('found worksheet', sheetNo)
     if (options.worksheets === 'emit') {
       this.emit('worksheet', worksheetReader);
     }

--- a/lib/utils/stuttered-pipe.js
+++ b/lib/utils/stuttered-pipe.js
@@ -42,7 +42,7 @@ var StutteredPipe = module.exports = function(readable, writable, options) {
     this.scheduled = null;
     
     readable.on('end', function() {
-        console.log("Input Stream ended")
+        //console.log("Input Stream ended")
         self.eod = true;
         writable.end();
     });


### PR DESCRIPTION
These log messages appear in our automatic tests.

I notice you've used commented logs throughout. Would it be useful to you if I switched it over to `debug` so you can turn them on/off with env vars rather than comments? It's easy to forget to re-comment them, which I assume is why they're here!