### PR TITLE
fix "read property 'richText' of undefined"

### DIFF
--- a/lib/xlsx/xform/shared-string-xform.js
+++ b/lib/xlsx/xform/shared-string-xform.js
@@ -39,7 +39,7 @@ var BaseXform = require('./base-xform');
 
 var SharedStringXform = module.exports = function(model) {
   this.model = model;
-  
+
   this.map = {
     r: new RichTextXform(),
     t: new TextXform()
@@ -48,10 +48,10 @@ var SharedStringXform = module.exports = function(model) {
 
 
 utils.inherits(SharedStringXform, BaseXform, {
-  
+
   write: function(xmlStream, model) {
     model = model || this.model;
-    
+
     xmlStream.openNode('si');
     if (model.richText) {
       var r = this.map.r;

--- a/lib/xlsx/xform/shared-string-xform.js
+++ b/lib/xlsx/xform/shared-string-xform.js
@@ -53,7 +53,7 @@ utils.inherits(SharedStringXform, BaseXform, {
     model = model || this.model;
 
     xmlStream.openNode('si');
-    if (model.richText) {
+    if (model && _.has(model, 'richText') && model.richText) {
       var r = this.map.r;
       _.each(model.richText, function(text) {
         r.write(xmlStream, text);


### PR DESCRIPTION
fix #120, which happens when adding a row with empty string:

```js
  sheet.addRow({
    bar: 'exceljs',
    foo: ''
  });
```