### PR TITLE
Fixed exceptions when defined name value aren't valid cell reference

### DIFF
--- a/lib/doc/defined-names.js
+++ b/lib/doc/defined-names.js
@@ -26,6 +26,7 @@ var utils = require('../utils/utils');
 var colCache = require('../utils/col-cache');
 var CellMatrix = require('../utils/cell-matrix');
 var Range = require('./range');
+var rangeRegexp = /\$(\w+)\$(\d+)(:\$(\w+)\$(\d+))?/;
 
 var DefinedNames = module.exports = function() {
   this.matrixMap = {};
@@ -173,7 +174,9 @@ DefinedNames.prototype = {
     _.each(value, function(definedName) {
       var matrix = matrixMap[definedName.name] = new CellMatrix();
       _.each(definedName.ranges, function(rangeStr) {
-        matrix.addCell(rangeStr);
+        if(rangeRegexp.test(rangeStr.split('!').pop() || '')) {
+          matrix.addCell(rangeStr);
+        }
       });
     });
   }

--- a/lib/utils/col-cache.js
+++ b/lib/utils/col-cache.js
@@ -170,8 +170,8 @@ var colCache = module.exports = {
 
     var parts = value.split('!');
     if (parts.length > 1) {
-      sheetName = parts[0];
-      value = parts[1];
+      value = parts.pop();
+      sheetName = parts.join('!').replace(/^'|'$/g, '');
     }
 
     parts = value.split(':');

--- a/lib/xlsx/xform/defined-names-xform.js
+++ b/lib/xlsx/xform/defined-names-xform.js
@@ -23,7 +23,6 @@
 'use strict';
 var _ = require('underscore');
 
-var XmlStream = require('../../utils/xml-stream');
 var utils = require('../../utils/utils');
 var BaseXform = require('./base-xform');
 
@@ -40,7 +39,7 @@ utils.inherits(DefinedNamesXform, BaseXform, {
 
     if (model && model.length) {
       xmlStream.openNode('definedNames');
-      _.each(this.model, function(definedName) {
+      _.each(model, function(definedName) {
         xmlStream.openNode('definedName');
         xmlStream.addAttribute('name', definedName.name);
         xmlStream.writeText(definedName.ranges.join(','));
@@ -58,13 +57,43 @@ utils.inherits(DefinedNamesXform, BaseXform, {
   parseClose: function(name) {
     this.model.push({
       name: this._parsedName,
-      ranges: this._parsedText.join('')
-        .split(',')
-        .filter(function (range) {
-          return range;
-        })
+      ranges: extractRanges(this._parsedText.join(''))
     });
     this._parsedName = undefined;
     this._parsedText = undefined;
   }
 });
+
+function extractRanges(parsedText) {
+  var ranges = [];
+  var quotesOpened = false;
+  var last = '';
+  parsedText.split(',').forEach(function (item) {
+    if(!item){
+      return;
+    }
+    var quotes = (item.match(/'/g) || []).length;
+
+    if (!quotes) {
+      if (quotesOpened) {
+        last += item + ',';
+      } else {
+        ranges.push(item);
+      }
+      return;
+    }
+    var quotesEven = quotes % 2 === 0;
+
+    if (!quotesOpened && quotesEven) {
+      ranges.push(item);
+    } else if (quotesOpened && !quotesEven) {
+      quotesOpened = false;
+      ranges.push(last + item);
+      last = '';
+    } else {
+      quotesOpened = true;
+      last += item + ',';
+    }
+  });
+  return ranges;
+}

--- a/spec/unit/doc/defined-names.spec.js
+++ b/spec/unit/doc/defined-names.spec.js
@@ -17,6 +17,11 @@ describe('DefinedNames', function() {
     dn.add('blort!$B$4','bar');
     expect(dn.getNames('blort!B4')).to.deep.equal(['bar']);
     expect(dn.getNames('blort!$B$4')).to.deep.equal(['bar']);
+
+    dn.add("'blo rt'!$B$4",'bar');
+    expect(dn.getNames("'blo rt'!$B$4")).to.deep.equal(['bar']);
+    dn.add("'blo ,!rt'!$B$4",'bar');
+    expect(dn.getNames("'blo ,!rt'!$B$4")).to.deep.equal(['bar']);
   });
 
   it('removes names for cells', function() {
@@ -52,6 +57,31 @@ describe('DefinedNames', function() {
     expect(dn.getRanges('horizontal')).to.deep.equal({name: 'horizontal', ranges: ['blort!$C$1:$E$1']});
     expect(dn.getRanges('square')).to.deep.equal({name: 'square', ranges: ['blort!$C$3:$D$4']});
     expect(dn.getRanges('single')).to.deep.equal({name: 'single', ranges: ['other!$A$1']});
+  });
+
+  it('creates matrix from model', function() {
+    var dn = new DefinedNames();
+
+    dn.model = [];
+    dn.add('blort!A1','bar');
+    dn.remove('blort!A1','foo');
+
+    expect(dn.getNames('blort!A1')).to.deep.equal(['bar']);
+  });
+
+  it('skips values with invalid range', function() {
+    var dn = new DefinedNames();
+    dn.model = [
+      {name: 'eq', ranges: ['"="']},
+      {name: 'ref', ranges: ['#REF!']},
+      {name: 'single', ranges: ['Sheet3!$A$1']},
+      {name: 'range', ranges: ['Sheet3!$A$2:$F$2228']}
+    ];
+
+    expect(dn.model).to.deep.equal([
+      {name: 'single', ranges: ['Sheet3!$A$1']},
+      {name: 'range', ranges: ['Sheet3!$A$2:$F$2228']}
+    ]);
   });
 
 });

--- a/spec/unit/utils/col-cache.spec.js
+++ b/spec/unit/utils/col-cache.spec.js
@@ -70,6 +70,12 @@ describe('colCache', function() {
     expect(colCache.decodeAddress('AA11')).to.deep.equal({address:'AA11',col:27, row: 11, $col$row: '$AA$11'});
   });
 
+  it('convert [sheetName!][$]col[$]row[[$]col[$]row] into address or range structures', function() {
+    expect(colCache.decodeEx('Sheet1!$H$1')).to.deep.equal({'$col$row':'$H$1', address:'H1', col:8, row:1, sheetName:'Sheet1'});
+    expect(colCache.decodeEx("'Sheet 1'!$H$1")).to.deep.equal({'$col$row':'$H$1', address:'H1', col:8, row:1, sheetName:'Sheet 1'});
+    expect(colCache.decodeEx("'Sheet !$:1'!$H$1")).to.deep.equal({'$col$row':'$H$1', address:'H1', col:8, row:1, sheetName:'Sheet !$:1'});
+  });
+
   it('gets address structures (and caches them)', function() {
     var addr = colCache.getAddress('D5');
     expect(addr.address).to.equal('D5');

--- a/spec/unit/xlsx/xform/defined-names-xform.spec.js
+++ b/spec/unit/xlsx/xform/defined-names-xform.spec.js
@@ -18,4 +18,34 @@ describe('DefinedNamesXform', function() {
     var dnx = new DefinedNamesXform(model);
       expect(dnx.xml).to.equal(xml);
   });
+
+  it('parses ranges', function() {
+    var dnx = new DefinedNamesXform();
+    dnx.parseOpen({attributes: {name: 'single'}});
+    dnx.parseText("'Sheet name'',$''!$'!$A$2");
+    dnx.parseClose();
+
+    dnx.parseOpen({attributes: {name: 'range'}});
+    dnx.parseText("'Sheet name'',$''!$'!$A$1:$B$1");
+    dnx.parseClose();
+
+    dnx.parseOpen({attributes: {name: 'multiple'}});
+    dnx.parseText("'Sheet name''$''!$'!$A$2,'Sheet name''$''!$'!$H$7,'Sheet3!'!$A$1,Sheet3!$A$1");
+    dnx.parseClose();
+
+    expect(dnx.model).to.deep.equal([
+      {name: 'single', ranges: ["'Sheet name'',$''!$'!$A$2"]},
+      {name: 'range', ranges: ["'Sheet name'',$''!$'!$A$1:$B$1"]},
+      {
+        name: 'multiple',
+        ranges: [
+          "'Sheet name''$''!$'!$A$2",
+          "'Sheet name''$''!$'!$H$7",
+          "'Sheet3!'!$A$1",
+          "Sheet3!$A$1"
+        ]
+      }
+    ]);
+  });
+
 });


### PR DESCRIPTION
Defined name values can be not only references, for example I have received excel with `=#REF!#REF!` and it crashed node during processing. 

Original stack-trace:
```
TypeError: Cannot read property '0' of null
    at Object.module.exports.decodeAddress (node_modules/exceljs/lib/utils/col-cache.js:111:36)
    at Object.module.exports.decodeEx (node_modules/exceljs/lib/utils/col-cache.js:197:26)
    at Object.CellMatrix.addCell (node_modules/exceljs/lib/utils/cell-matrix.js:36:29)
    at node_modules/exceljs/lib/doc/defined-names.js:176:16
    at Array.forEach (native)
    at Function._.each._.forEach (node_modules/underscore/underscore.js:78:11)
    at node_modules/exceljs/lib/doc/defined-names.js:175:9
    at Array.forEach (native)
    at Function._.each._.forEach (node_modules/underscore/underscore.js:78:11)
    at Object.model (node_modules/exceljs/lib/doc/defined-names.js:173:7)
    at Object.model (node_modules/exceljs/lib/doc/workbook.js:146:30)
    at node_modules/exceljs/lib/xlsx/xlsx.js:601:31
    at tryCatcher (node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromiseAtPostResolution (node_modules/bluebird/js/main/promise.js:245:10)
    at Async._drainQueue (node_modules/bluebird/js/main/async.js:128:12)
    at Async._drainQueues (node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```