### PR TITLE
Protect cell fix

### DIFF
--- a/lib/xlsx/xform/style/style-xform.js
+++ b/lib/xlsx/xform/style/style-xform.js
@@ -71,7 +71,7 @@ utils.inherits(StyleXform, BaseXform, {
       xmlStream.addAttribute('applyAlignment', '1');
       this.map.alignment.render(xmlStream, model.alignment);
     }
-    
+
     xmlStream.closeNode();
   },
 
@@ -115,7 +115,7 @@ utils.inherits(StyleXform, BaseXform, {
       }
       return true;
     } else {
-      return false;
+      return name !== 'xf';
     }
   }
 });


### PR DESCRIPTION
Integer cell values are interpreted as Dates based on `cellXfs.xf` elements in `xl/styles.xml`.  However, when any spreadsheet has "protected" cells, these `xf` elements can have the form:

```xml
<xf borderId="1" fillId="10" fontId="3" numFmtId="0" xfId="0" applyProtection="1" applyAlignment="1" applyFill="1" applyBorder="1" applyFont="1">
  <alignment horizontal="center" vertical="center"/>
  <protection locked="0"/>
</xf>
```

Currently, unknown child elements of `xf` elements are not handled correctly and this causes `xl/styles.xml` to be parsed incorrectly (this is the root of the problem).  When `xl/styles.xml` is parsed incorrectly, the `lib/xlsx/style/styles-xform.js` method `getStyleModel` can fail to find the `numFmt` for Date types.  The change here does not have to be "the fix" (you/we can also add an xform for protected elements) but it does fix the problem since unknown child cells of `xf` elements will not cause the parent `ListXform.parseClose` to remove the `parser`.  

Since exceljs may not be able to account for all possible element types in the xml files, it should *at least* ignore unknown elements and only process those that it knows how to "handle."  This way exceljs will do its best to work correctly for the subset of features it supports.

Let me know if more info is needed.