### PR TITLE
Update border-xform.js

### DIFF
--- a/lib/xlsx/xform/style/border-xform.js
+++ b/lib/xlsx/xform/style/border-xform.js
@@ -98,6 +98,8 @@ utils.inherits(EdgeXform, BaseXform, {
     } else {
       if (name === this.name) {
         if (this.map.color.model) {
+          if(!this.model)
+            this.model={};
           this.model.color = this.map.color.model;
         }
       }


### PR DESCRIPTION
i was getting below error in simple read of excel file. after changes i was able to read the file:


D:\IZ3.0\Code\DataLoader\node_modules\exceljs\lib\xlsx\xform\style\border-xform.
js:101
          this.model.color = this.map.color.model;
                           ^

TypeError: Cannot set property 'color' of undefined
    at utils.inherits.parseClose (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\
lib\xlsx\xform\style\border-xform.js:101:28)
    at utils.inherits.parseClose (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\
lib\xlsx\xform\style\border-xform.js:198:24)
    at utils.inherits.parseClose (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\
lib\xlsx\xform\list-xform.js:90:24)
    at utils.inherits.parseClose (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\
lib\xlsx\xform\style\styles-xform.js:222:24)
    at SAXStream.<anonymous> (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\lib\
xlsx\xform\base-xform.js:71:19)
    at emitOne (events.js:77:13)
    at SAXStream.emit (events.js:169:7)
    at Object.me._parser.(anonymous function) [as onclosetag] (D:\IZ3.0\Code\Dat
aLoader\node_modules\exceljs\node_modules\sax\lib\sax.js:245:15)
    at emit (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\node_modules\sax\lib\
sax.js:615:33)
    at emitNode (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\node_modules\sax\
lib\sax.js:620:3)
    at closeTag (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\node_modules\sax\
lib\sax.js:861:5)
    at Object.write (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\node_modules\
sax\lib\sax.js:1182:11)
    at SAXStream.write (D:\IZ3.0\Code\DataLoader\node_modules\exceljs\node_modul
es\sax\lib\sax.js:227:16)
    at Entry.ondata (_stream_readable.js:542:20)
    at emitOne (events.js:77:13)
    at Entry.emit (events.js:169:7)