### PR TITLE
Pass views to worksheet-writer

### DIFF
--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -177,7 +177,8 @@ WorkbookWriter.prototype = {
       workbook: this,
       useSharedStrings: useSharedStrings,
       properties: options.properties,
-      pageSetup: options.pageSetup
+      pageSetup: options.pageSetup,
+      views: options.views
     });
 
     this._worksheets[id] = worksheet;


### PR DESCRIPTION
Views wheren't passed to worksheet-writer from workbook-writer.

If you wanted for example to define frozen columns or rows, this was not previously possible when using the Streaming I/O.

The handling for views already excised in the worksheet-writer, but the option simply wasn't passed. 