### PR TITLE
fix typo on sheet view showGridLines option

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Each view also supports various properties:
 | activeCell        | undefined | The currently selected cell |
 | showRuler         | true      | Shows or hides the ruler in Page Layout |
 | showRowColHeaders | true      | Shows or hides the row and column headers (e.g. A1, B1 at the top and 1,2,3 on the left |
-| showGridlines     | true      | Shows or hides the gridlines (shown for cells where borders have not been defined) |
+| showGridLines     | true      | Shows or hides the gridlines (shown for cells where borders have not been defined) |
 | zoomScale         | 100       | Percentage zoom to use for the view |
 | zoomScaleNormal   | 100       | Normal zoom for the view |
 | style             | undefined | Presentation style - one of pageBreakPreview or pageLayout. Note pageLayout is not compatable with frozen views |

--- a/lib/xlsx/xform/sheet/sheet-view-xform.js
+++ b/lib/xlsx/xform/sheet/sheet-view-xform.js
@@ -62,7 +62,7 @@ utils.inherits(SheetViewXform, BaseXform, {
     add('tabSelected', '1', model.tabSelected);
     add('showRuler', '0', model.showRuler === false);
     add('showRowColHeaders', '0', model.showRowColHeaders === false);
-    add('showGridlines', '0', model.showGridlines === false);
+    add('showGridLines', '0', model.showGridLines === false);
     add('zoomScale', model.zoomScale, model.zoomScale);
     add('zoomScaleNormal', model.zoomScaleNormal, model.zoomScaleNormal);
     add('view', model.style, model.style);
@@ -131,7 +131,7 @@ utils.inherits(SheetViewXform, BaseXform, {
           tabSelected: node.attributes.tabSelected === '1',
           showRuler: !(node.attributes.showRuler === '0'),
           showRowColHeaders: !(node.attributes.showRowColHeaders === '0'),
-          showGridlines: !(node.attributes.showGridlines === '0'),
+          showGridLines: !(node.attributes.showGridLines === '0'),
           zoomScale: parseInt(node.attributes.zoomScale || 100),
           zoomScaleNormal: parseInt(node.attributes.zoomScaleNormal || 100),
           style: node.attributes.view
@@ -174,7 +174,7 @@ utils.inherits(SheetViewXform, BaseXform, {
             topLeftCell: this.pane.topLeftCell,
             showRuler: this.sheetView.showRuler,
             showRowColHeaders: this.sheetView.showRowColHeaders,
-            showGridlines: this.sheetView.showGridlines,
+            showGridLines: this.sheetView.showGridLines,
             zoomScale: this.sheetView.zoomScale,
             zoomScaleNormal: this.sheetView.zoomScaleNormal
           };
@@ -194,7 +194,7 @@ utils.inherits(SheetViewXform, BaseXform, {
             state: 'normal',
             showRuler: this.sheetView.showRuler,
             showRowColHeaders: this.sheetView.showRowColHeaders,
-            showGridlines: this.sheetView.showGridlines,
+            showGridLines: this.sheetView.showGridLines,
             zoomScale: this.sheetView.zoomScale,
             zoomScaleNormal: this.sheetView.zoomScaleNormal
           };

--- a/spec/integration/workbook.spec.js
+++ b/spec/integration/workbook.spec.js
@@ -497,15 +497,15 @@ describe('Workbook', function() {
           expect(ws2.views).to.deep.equal([
             {
               workbookViewId: 0, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4',
-              activeCell: 'D5', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
+              activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
             },
             {
               workbookViewId: 0, state: 'frozen', xSplit: 0, ySplit: 1, topLeftCell: 'A2',
-              showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
+              showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
             },
             {
               workbookViewId: 0, state: 'frozen', xSplit: 1, ySplit: 0, topLeftCell: 'B1',
-              showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
+              showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
             }
           ])
         });
@@ -532,15 +532,15 @@ describe('Workbook', function() {
           expect(ws2.views).to.deep.equal([
             {
               workbookViewId: 0, state: 'split', xSplit: 2000, ySplit: 3000, topLeftCell: 'C4', activeCell: 'D5', activePane: 'bottomRight',
-              showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
+              showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
             },
             {
               workbookViewId: 0, state: 'split', xSplit: 0, ySplit: 1500, topLeftCell: 'A10', activePane: 'bottomLeft',
-              showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
+              showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
             },
             {
               workbookViewId: 0, state: 'split', xSplit: 1500, ySplit: 0, topLeftCell: undefined, activePane: 'topRight',
-              showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
+              showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100
             }
           ])
         });

--- a/spec/unit/xlsx/xform/sheet/data/sheet.1.3.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.1.3.json
@@ -5,7 +5,7 @@
     "tabColor": {"argb": "FF00FF00"},
     "outlineLevelCol": 0, "outlineLevelRow": 0
   },
-  "views": [{"state": "normal", "showRuler": true, "showGridlines": true, "showRowColHeaders": true, "zoomScale": 100, "zoomScaleNormal": 100, "workbookViewId": 0}],
+  "views": [{"state": "normal", "showRuler": true, "showGridLines": true, "showRowColHeaders": true, "zoomScale": 100, "zoomScaleNormal": 100, "workbookViewId": 0}],
   "pageSetup": {
     "margins": {"left": 0.7, "right": 0.7, "top": 0.75, "bottom": 0.75, "header": 0.3, "footer":  0.3 },
     "firstPageNumber": 5, "useFirstPageNumber": true, "usePrinterDefaults": true, "copies": 3,

--- a/spec/unit/xlsx/xform/sheet/data/sheet.1.4.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.1.4.json
@@ -5,7 +5,7 @@
     "tabColor": {"argb": "FF00FF00"},
     "outlineLevelCol": 0, "outlineLevelRow": 0
   },
-  "views": [{"state": "normal", "showRuler": true, "showGridlines": true, "showRowColHeaders": true, "zoomScale": 100, "zoomScaleNormal": 100}],
+  "views": [{"state": "normal", "showRuler": true, "showGridLines": true, "showRowColHeaders": true, "zoomScale": 100, "zoomScaleNormal": 100}],
   "pageSetup": {
     "margins": {"left": 0.7, "right": 0.7, "top": 0.75, "bottom": 0.75, "header": 0.3, "footer":  0.3 },
     "firstPageNumber": 5, "useFirstPageNumber": true, "usePrinterDefaults": true, "copies": 3,

--- a/spec/unit/xlsx/xform/sheet/sheet-view-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/sheet-view-xform.spec.js
@@ -13,7 +13,7 @@ var expectations = [
     xml:  '<sheetView workbookViewId="0">' +
             '<selection activeCell="G4" sqref="G4"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -23,17 +23,17 @@ var expectations = [
     xml:  '<sheetView workbookViewId="0" zoomScale="60" zoomScaleNormal="80">' +
             '<selection activeCell="G4" sqref="G4"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 60, zoomScaleNormal: 80},
+    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 60, zoomScaleNormal: 80},
     tests: ['render', 'renderIn', 'parse']
   },
   {
     title: 'Normal unruly noliney nohdr',
     create:  function() { return new SheetViewXform()},
-    preparedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: false, showGridlines: false, showRowColHeaders: false},
-    xml:  '<sheetView workbookViewId="0" showRuler="0" showGridlines="0" showRowColHeaders="0">' +
+    preparedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: false, showGridLines: false, showRowColHeaders: false},
+    xml:  '<sheetView workbookViewId="0" showRuler="0" showGridLines="0" showRowColHeaders="0">' +
             '<selection activeCell="G4" sqref="G4"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: false, showGridlines: false, showRowColHeaders: false, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: false, showGridLines: false, showRowColHeaders: false, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -43,7 +43,7 @@ var expectations = [
     xml:  '<sheetView workbookViewId="0" view="pageBreakPreview">' +
             '<selection activeCell="G4" sqref="G4"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100, style: 'pageBreakPreview'},
+    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100, style: 'pageBreakPreview'},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -54,7 +54,7 @@ var expectations = [
             '<pane xSplit="1234" ySplit="3456" topLeftCell="C3" activePane="bottomRight"/>' +
             '<selection pane="bottomRight" activeCell="B1" sqref="B1"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'B1', activePane: 'bottomRight', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'B1', activePane: 'bottomRight', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -65,7 +65,7 @@ var expectations = [
             '<pane xSplit="1234" ySplit="3456" topLeftCell="C3"/>' +
             '<selection activeCell="A1" sqref="A1"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'A1', activePane: 'topLeft', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'A1', activePane: 'topLeft', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -76,7 +76,7 @@ var expectations = [
             '<pane xSplit="2" ySplit="3" topLeftCell="C4" activePane="bottomRight" state="frozen"/>' +
             '<selection pane="bottomRight" activeCell="D5" sqref="D5"/>' +
           '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -96,8 +96,8 @@ var expectations = [
             '</sheetView>'  +
           '</sheetViews>',
     parsedModel: [
-      {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
-      {workbookViewId: 1, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridlines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100}
+      {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+      {workbookViewId: 1, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100}
     ],
     tests: ['render', 'renderIn', 'parse']
   }

--- a/spec/utils/data/views.json
+++ b/spec/utils/data/views.json
@@ -18,7 +18,7 @@
       "topLeftCell": "C4",
       "activeCell": "D5",
       "showRuler": true,
-      "showGridlines": true,
+      "showGridLines": true,
       "showRowColHeaders": true,
       "zoomScale": 100,
       "zoomScaleNormal": 100
@@ -32,7 +32,7 @@
       "activeCell": "D5",
       "activePane": "bottomRight",
       "showRuler": true,
-      "showGridlines": true,
+      "showGridLines": true,
       "showRowColHeaders": true,
       "zoomScale": 100,
       "zoomScaleNormal": 100


### PR DESCRIPTION
According to the [documentation](https://msdn.microsoft.com/en-us/library/documentformat.openxml.spreadsheet.sheetview.showgridlines(v=office.14).aspx) the showGridLines var in worksheet views options is misspelled. It should be "showGridLines", not "showGridlines".

I changed all the files, and now it is working. 