### PR TITLE
Listen for finish event on zip stream instead of middle stream

### DIFF
--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -317,7 +317,7 @@ WorkbookWriter.prototype = {
       self.stream.on('error', function(error){
         reject(error);
       });
-      self.stream.on('finish', function(){
+      self.zip.on('finish', function(){
         resolve(self);
       });
       self.zip.on('error', function(error){


### PR DESCRIPTION
Fix of https://github.com/guyonroche/exceljs/issues/198