### PR TITLE
Fix issue #163: the "spans" attribute of the row element is optional

### DIFF
--- a/lib/xlsx/sheet.xml
+++ b/lib/xlsx/sheet.xml
@@ -42,7 +42,7 @@
            <% if(row.height) {%> ht="<%=row.height%>" customHeight="1"<% } %>
            <% if(row.hidden) {%> hidden="1"<% } %>
            <% if(row.outlineLevel) {%> outlineLevel="<%=row.outlineLevel%>"<% } %>
-           spans="<%=row.min%>:<%=row.max%>"
+           <% if(row.min > 0 && row.max > 0 && row.min <= row.max) {%> spans="<%=row.min%>:<%=row.max%>"<% } %>
            <% if (row.styleId) { %> s="<%=row.styleId%>" customFormat="1" <% } %>
            x14ac:dyDescent="0.25">
       <% row.cells.forEach(function(cell){ %>

--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -36,7 +36,7 @@ var RowXform = module.exports = function() {
 // <row r="<%=row.number%>"
 //     <% if(row.height) {%> ht="<%=row.height%>" customHeight="1"<% } %>
 //     <% if(row.hidden) {%> hidden="1"<% } %>
-//     spans="<%=row.min%>:<%=row.max%>"
+//     <% if(row.min > 0 && row.max > 0 && row.min <= row.max) {%> spans="<%=row.min%>:<%=row.max%>"<% } %>
 //     <% if (row.styleId) { %> s="<%=row.styleId%>" customFormat="1" <% } %>
 //     x14ac:dyDescent="0.25">
 //   <% row.cells.forEach(function(cell){ %>
@@ -68,7 +68,9 @@ utils.inherits(RowXform, BaseXform, {
     if (model.hidden) {
       xmlStream.addAttribute('hidden',  '1');
     }
-    xmlStream.addAttribute('spans', model.min + ':' + model.max);
+    if (model.min > 0 && model.max > 0 && model.min <= model.max) {
+      xmlStream.addAttribute('spans', model.min + ':' + model.max);
+    }
     if (model.styleId) {
       xmlStream.addAttribute('s',  model.styleId);
       xmlStream.addAttribute('customFormat', '1');
@@ -94,7 +96,7 @@ utils.inherits(RowXform, BaseXform, {
       this.parser.parseOpen(node);
       return true;
     } else if (node.name === 'row') {
-      var spans = node.attributes.spans.split(':').map(function(span) { return parseInt(span); });
+      var spans = node.attributes.spans ? node.attributes.spans.split(':').map(function(span) { return parseInt(span); }) : [undefined, undefined];
       var model = this.model = {
         number: parseInt(node.attributes.r),
         min: spans[0],

--- a/spec/unit/xlsx/xform/sheet/row-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/row-xform.spec.js
@@ -32,6 +32,17 @@ var expectations = [
     options: { sharedStrings: new SharedStringsXform(), styles: fakeStyles, hyperlinkMap: fakeHyperlinkMap }
   },
   {
+    title: 'No spans',
+    create:  function() { return new RowXform()},
+    initialModel: {number: 1, style: {}, cells: [{address: 'A1', type: Enums.ValueType.Number, value: 5}]},
+    get preparedModel() { return this.initialModel; },
+    xml: '<row r="1" x14ac:dyDescent="0.25"><c r="A1"><v>5</v></c></row>',
+    parsedModel: {number: 1, cells: [{address: 'A1', type: Enums.ValueType.Number, value: 5}]},
+    reconciledModel: {number: 1, cells: [{address: 'A1', type: Enums.ValueType.Number, value: 5}], style: {}},
+    tests: ['prepare', 'render', 'renderIn', 'parse', 'reconcile'],
+    options: { sharedStrings: new SharedStringsXform(), styles: fakeStyles, hyperlinkMap: fakeHyperlinkMap }
+  },
+  {
     title: 'Styled',
     create:  function() { return new RowXform()},
     initialModel: {number: 2, min:1, max: 1, style: {numFmt: '#'}, cells: [{address: 'A2', type: Enums.ValueType.Number, value: 5}]},


### PR DESCRIPTION
The "spans" attribute is not required in the "row" element. Source of information: https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.spreadsheet.row.aspx

If we create a Google Sheets spreadsheet and download it as XLSX, then the "spans" attributes do not appear in the "row" elements of the worksheet.

Attached is a test xlsx file, which causes the "Cannot read property 'split' of undefined" error when trying to read it with the exceljs package.
[test-issue-163.xlsx](https://github.com/guyonroche/exceljs/files/542029/test-issue-163.xlsx)
