### PR TITLE
utc Offsset to excelToDate and dateToExcel

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -119,10 +119,12 @@ var utils = module.exports = {
   },
   inherits: inherits,
   dateToExcel: function(d) {
-    return 25569 + d.getTime() / (24 * 3600 * 1000);
+    return 25569 + (d.getTime() - d.getTimezoneOffset()*60*1000) / (24 * 3600 * 1000);
   },
   excelToDate: function(v) {
-    return new Date((v - 25569) * 24 * 3600 * 1000);
+    var d = new Date((v - 25569) * 24 * 3600 * 1000);
+    d.setMinutes(d.getMinutes() + d.getTimezoneOffset());
+    return d;
   },
   parsePath: function(filepath) {
     var last = filepath.lastIndexOf('/');


### PR DESCRIPTION
updated excelToDate and dateToExcel to consider utc Offset.
If my machine's timezone is GMT+0530 and my date in Date object is 20-Oct-2016 00:00:00 then in excel file written with exceljs it is shown as 19-Oct-2016 06:30:00 PM.
