### PR TITLE
Allow styling of cells with no value.

### DIFF
--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -291,7 +291,6 @@ Row.prototype = {
     var min = 0;
     var max = 0;
     this._cells.forEach(function (cell) {
-      if (cell && (cell.type != Enums.ValueType.Null)) {
         var cellModel = cell.model;
         if (cellModel) {
           if (!min || (min > cell.col)) {
@@ -302,7 +301,6 @@ Row.prototype = {
           }
           cells.push(cellModel);
         }
-      }
     });
 
     return (this.height || cells.length) ? {

--- a/lib/xlsx/xform/book/workbook-xform.js
+++ b/lib/xlsx/xform/book/workbook-xform.js
@@ -71,7 +71,7 @@ utils.inherits(WorkbookXform, BaseXform, {
       if (sheet.pageSetup && sheet.pageSetup.printArea) {
         var definedName = {
           name: '_xlnm.Print_Area',
-          ranges: [sheet.pageSetup.printArea],
+          ranges: ['\'' + sheet.name + '\'!' + sheet.pageSetup.printArea],
           localSheetId: index
         };
         printAreas.push(definedName);


### PR DESCRIPTION
Currently it is not possible to apply styles to an empty cell and have them rendered. The cell must be given a value to be included in the render. This means you cannot let text from one cell flow over in to an adjacent cell (left or right ) with styling.  This commit causes 1, possibly 2 tests to fail. I can (and will) make the tests pass fairly quickly. Is there any implication I am missing?
