### PR TITLE
Fix "Unexpected xml node in parseOpen" bug in LibreOffice documents for attributes dc:language and cp:revision

### DIFF
--- a/lib/xlsx/xform/core/core-xform.js
+++ b/lib/xlsx/xform/core/core-xform.js
@@ -33,6 +33,7 @@ var props = {
   title: 'Title',
   subject: 'Subject',
   description: 'Comments',
+  language: 'Language',
   keywords: 'Tags',
   category: 'Categories'
 };
@@ -43,12 +44,14 @@ var CoreXform = module.exports = function() {
     'dc:title': new StringXform({tag: 'dc:title'}),
     'dc:subject': new StringXform({tag: 'dc:subject'}),
     'dc:description': new StringXform({tag: 'dc:description'}),
+    'dc:language': new StringXform({tag: 'dc:language'}),
     'cp:keywords': new StringXform({tag: 'cp:keywords'}),
     'cp:category': new StringXform({tag: 'cp:category'}),
     'cp:lastModifiedBy': new StringXform({tag: 'cp:lastModifiedBy'}),
     'cp:lastPrinted': new DateXform({tag: 'cp:lastPrinted', format: CoreXform.DateFormat}),
+    'cp:revision': new DateXform({tag: 'cp:revision'}),
     'dcterms:created': new DateXform({tag: 'dcterms:created', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat}),
-    'dcterms:modified': new DateXform({tag: 'dcterms:modified', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat})
+    'dcterms:modified': new DateXform({tag: 'dcterms:modified', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat}),
   }
 };
 
@@ -75,10 +78,12 @@ utils.inherits(CoreXform, BaseXform, {
     this.map['dc:title'].render(xmlStream, model.title);
     this.map['dc:subject'].render(xmlStream, model.subject);
     this.map['dc:description'].render(xmlStream, model.description);
+    this.map['dc:language'].render(xmlStream, model.language);
     this.map['cp:keywords'].render(xmlStream, model.keywords);
     this.map['cp:category'].render(xmlStream, model.category);
     this.map['cp:lastModifiedBy'].render(xmlStream, model.lastModifiedBy);
     this.map['cp:lastPrinted'].render(xmlStream, model.lastPrinted);
+    this.map['cp:revision'].render(xmlStream, model.revision);
     this.map['dcterms:created'].render(xmlStream, model.created);
     this.map['dcterms:modified'].render(xmlStream, model.modified);
 
@@ -122,10 +127,12 @@ utils.inherits(CoreXform, BaseXform, {
             title: this.map['dc:title'].model,
             subject: this.map['dc:subject'].model,
             description: this.map['dc:description'].model,
+            language: this.map['dc:language'].model,
             keywords: this.map['cp:keywords'].model,
             category: this.map['cp:category'].model,
             lastModifiedBy: this.map['cp:lastModifiedBy'].model,
             lastPrinted: this.map['cp:lastPrinted'].model,
+            Revision: this.map['cp:revision'].model,
             created: this.map['dcterms:created'].model,
             modified: this.map['dcterms:modified'].model
           };

--- a/lib/xlsx/xform/core/core-xform.js
+++ b/lib/xlsx/xform/core/core-xform.js
@@ -51,7 +51,7 @@ var CoreXform = module.exports = function() {
     'cp:lastPrinted': new DateXform({tag: 'cp:lastPrinted', format: CoreXform.DateFormat}),
     'cp:revision': new DateXform({tag: 'cp:revision'}),
     'dcterms:created': new DateXform({tag: 'dcterms:created', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat}),
-    'dcterms:modified': new DateXform({tag: 'dcterms:modified', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat}),
+    'dcterms:modified': new DateXform({tag: 'dcterms:modified', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat})
   }
 };
 


### PR DESCRIPTION
Referring to #176 I still had errors thrown for the attributes dc:language and cp:revision when reading from .xlsx files created with LibreOffice. These changes fixed the issue for my use case. 

Please let me know if there is anything missing / should be optimized and I'll modify my PR. 
