### PR TITLE
Fix output order of Sheet Properties

### DIFF
--- a/lib/stream/xlsx/worksheet-writer.js
+++ b/lib/stream/xlsx/worksheet-writer.js
@@ -420,9 +420,10 @@ WorksheetWriter.prototype = {
     xml.addText('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>');
     xml.addText('<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">');
 
+    this._writeSheetProperties(xml, this.properties, this.pageSetup);
+
     xml.addText(xform.sheetViews.toXml(this.views));
 
-    this._writeSheetProperties(xml, this.properties, this.pageSetup);
     this._writeSheetFormatProperties(xml, this.properties);
 
     this.stream.write(xml);


### PR DESCRIPTION
I noticed that when using both "tabColors" and "sheetViews" the resulting xlsx files end up being corrupt when trying to open in Microsoft Excel. After playing around a bit in the zip files I realized Excel is pretty picky about element order in the xml files, and it prefers to have the Sheet Properties before the Sheet Views. 

Here is some example code that is corrupt before my change and opens fine after:

```var Excel = require('../exceljs/excel');
var wb = new Excel.stream.xlsx.WorkbookWriter({filename: "tabColorTest.xlsx", useSharedStrings: true});
var ws = wb.addWorksheet('blort', {
    properties: {
        tabColor: {argb: 'FFFF0000'}
    },
    views: [
        {
            state: 'frozen',
            ySplit: 1,
            topLeftCell:"A2"
        }
    ]
});

ws.getCell('A1').value = "frozenHeader";
ws.getCell('A2').value = "tabColorTest";
wb.commit();
```