### PR TITLE
remove empty worksheet[0] from _worksheets

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -120,7 +120,7 @@ Workbook.prototype = {
 
   get worksheets() {
     // return a clone of _worksheets
-    return this._worksheets.filter(function(worksheet) { return worksheet; });
+    return this._worksheets.filter(Boolean);
   },
 
   eachSheet: function(iteratee) {
@@ -140,7 +140,7 @@ Workbook.prototype = {
       lastPrinted: this.lastPrinted,
       created: this.created,
       modified: this.modified,
-      worksheets: this._worksheets.map(function(worksheet) { return worksheet.model; }),
+      worksheets: this._worksheets.filter(Boolean).map(function(worksheet) { return worksheet.model; }),
       definedNames: this._definedNames.model,
       views: this.views,
       company: this.company,

--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -228,7 +228,7 @@ WorkbookWriter.prototype = {
     var self = this;
     return new Bluebird(function(resolve) {
       var model = {
-        worksheets: self._worksheets
+        worksheets: self._worksheets.filter(Boolean)
       };
       var xform = new ContentTypesXform();
       var xml = xform.toXml(model);
@@ -240,7 +240,7 @@ WorkbookWriter.prototype = {
     var self = this;
     return new Bluebird(function(resolve) {
       var model = {
-        worksheets: self._worksheets
+        worksheets: self._worksheets.filter(Boolean)
       };
       var xform = new AppXform();
       var xml = xform.toXml(model);
@@ -300,7 +300,7 @@ WorkbookWriter.prototype = {
   addWorkbook: function() {
     var zip = this.zip;
     var model = {
-      worksheets: this._worksheets,
+      worksheets: this._worksheets.filter(Boolean),
       definedNames: this._definedNames.model,
       views: this.views
     };


### PR DESCRIPTION
_worksheets are saved as a loose array with undefined item[0]

when counting number of worksheets in xform models the .length is used - includes item[0]
when inserting worksheets into xml then .forEach method is used - excludes item[0]

this results in docProps/app.xml with data for a workbook with a single worksheet `foo` like:
```
<TitlesOfParts>
  <vt:vector size="2" baseType="lpstr">
    <vt:lpstr>foo</vt:lpstr>
  </vt:vector>
</TitlesOfParts>
```

error being in `vt:vector` of size 2 with only one item inside