### PR TITLE
do not skip empty string in shared strings so that indexes match

### DIFF
--- a/lib/xlsx/xform/strings/shared-string-xform.js
+++ b/lib/xlsx/xform/strings/shared-string-xform.js
@@ -60,7 +60,7 @@ utils.inherits(SharedStringXform, BaseXform, {
       model.richText.forEach(function(text) {
         r.render(xmlStream, text);
       });
-    } else if (model) {
+    } else if (model !== undefined && model !== null) {
       this.map.t.render(xmlStream, model);
     }
     xmlStream.closeNode();


### PR DESCRIPTION
when working with shared strings this library adds empty string into shared strings (as it should), but when the shared strings are processed into xml, the empty string is omitted

workbook with cells `['foo', '', 'bar']` creates `xl/sharedStrings.xml` like:
```
<sst xmlns="..." count="3" uniqueCount="3">
  <si><t>foo</t></si>
  <si/>
  <si><t>bar</t></si>
</sst>
```
with missing `<t>` tag in `<si>`

this results in missing shared string in some excel reading libs that do not count this `<si>` as a string

when the sheet is opened and resaved with MS Excel, the shares string includes an empty `<t>` tag