### PR TITLE
use shared strings for streamed writes

### DIFF
--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -56,7 +56,7 @@ var WorkbookWriter = module.exports = function(options) {
 
   // using shared strings creates a smaller xlsx file but may use more memory
   this.useSharedStrings = options.useSharedStrings || false;
-  this.streamedValues = new SharedStrings();
+  this.sharedStrings = new SharedStrings();
 
   // style manager
   this.styles = options.useStyles ? new StylesXform(true) : new StylesXform.Mock(true);
@@ -259,7 +259,7 @@ WorkbookWriter.prototype = {
   },
   addSharedStrings: function() {
     var self = this;
-    if (this.streamedValues.count) {
+    if (this.sharedStrings.count) {
       return new Bluebird(function(resolve) {
         var sharedStringsXform = new SharedStringsXform();
         var xml = sharedStringsXform.toXml(self.sharedStrings);
@@ -277,7 +277,7 @@ WorkbookWriter.prototype = {
       {rId: 'rId' + (count++), type: RelType.Styles, target: 'styles.xml'},
       {rId: 'rId' + (count++), type: RelType.Theme, target: 'theme/theme1.xml'}
     ];
-    if (this.streamedValues.count) {
+    if (this.sharedStrings.count) {
       relationships.push(
         {rId: 'rId' + (count++), type: RelType.SharedStrings, target: 'sharedStrings.xml'}
       );


### PR DESCRIPTION
stream writer did not use shared strings even if the useSharedStrings option was enabled due to variable name mismatch between
- `WorkbookWriter` - `lib/stream/xlsx/workbook-writer.js:59` - `this.streamedValues`
- `WorksheetWriter` - `lib/stream/xlsx/worksheet-writer.js:454` - `self._workbook.sharedStrings`