### PR TITLE
Sheets with hyperlinks and data validations are corrupted

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -115,8 +115,8 @@ utils.inherits(WorkSheetXform, BaseXform, {
     this.map.cols.render(xmlStream, model.cols);
     this.map.sheetData.render(xmlStream, model.rows);
     this.map.mergeCells.render(xmlStream, model.mergeCells);
-    this.map.hyperlinks.render(xmlStream, model.hyperlinks);
     this.map.dataValidations.render(xmlStream, model.dataValidations);
+    this.map.hyperlinks.render(xmlStream, model.hyperlinks);//For some reason hyperlinks have to be after the data validations
     this.map.pageMargins.render(xmlStream, pageMarginsModel);
     this.map.printOptions.render(xmlStream, printOptionsModel);
     this.map.pageSetup.render(xmlStream, model.pageSetup);


### PR DESCRIPTION
I was trying to convert a file that had both an hyperlink and data validations. For some obscure reason, Excel didn't want to open the resulting file. Putting the links after the data validations in the sheet's XML fixed the issue.
I'm not familiar enough with exceljs to write a test for this issue.