### PR TITLE
Minor fixes for stream handling

### DIFF
--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -319,7 +319,7 @@ WorkbookWriter.prototype = {
       self.stream.on('error', function(error){
         reject(error);
       });
-      self.zip.on('finish', function(){
+      self.stream.on('finish', function(){
         resolve(self);
       });
       self.zip.on('error', function(error){

--- a/lib/utils/zip-stream.js
+++ b/lib/utils/zip-stream.js
@@ -80,12 +80,12 @@ utils.inherits(ZipReader, events.EventEmitter, {
                 });
 
                 self.emit('entry', entryStream);
-              })
-              .catch(function (error) {
-                console.error('caught error', error.stack)
               });
           }
         });
+      })
+      .catch(function (error) {
+        self.emit('error', error);
       });
   },
 


### PR DESCRIPTION
I upgraded from 0.2.38 to 0.2.46 today, and a few of our testcases failed. I tracked it down to two issues:

* The catch handler on the zip parsing was missing, and also wasn't propagating the error via the event emitter.
* The workbook writer was resolving the write when the zip-stream was done, not when the underlying stream was done. This meant that the write could resolve, while f.ex. a file was still being written to disk.