### PR TITLE
Add support for cp:contentStatus

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -153,6 +153,7 @@ Workbook.prototype = {
       description: this.description,
       language: this.language,
       revision: this.revision,
+      contentStatus: this.contentStatus
     };
   },
   set model(value) {
@@ -173,6 +174,7 @@ Workbook.prototype = {
     this.description  = value.description;
     this.language = value.language;
     this.revision = value.revision;
+    this.contentStatus = value.contentStatus;
 
     this.properties = value.properties;
     this._worksheets = [];

--- a/lib/xlsx/xform/core/core-xform.js
+++ b/lib/xlsx/xform/core/core-xform.js
@@ -28,17 +28,6 @@ var BaseXform = require('../base-xform');
 var DateXform = require('../simple/date-xform');
 var StringXform = require('../simple/string-xform');
 
-var props = {
-  creator: 'Author',
-  title: 'Title',
-  subject: 'Subject',
-  description: 'Comments',
-  language: 'Language',
-  keywords: 'Tags',
-  category: 'Categories',
-  identifier: 'Identifier'
-};
-
 var CoreXform = module.exports = function() {
   this.map = {
     'dc:creator': new StringXform({tag: 'dc:creator'}),
@@ -52,6 +41,7 @@ var CoreXform = module.exports = function() {
     'cp:lastModifiedBy': new StringXform({tag: 'cp:lastModifiedBy'}),
     'cp:lastPrinted': new DateXform({tag: 'cp:lastPrinted', format: CoreXform.DateFormat}),
     'cp:revision': new DateXform({tag: 'cp:revision'}),
+    'cp:contentStatus': new StringXform({tag: 'cp:contentStatus'}),
     'dcterms:created': new DateXform({tag: 'dcterms:created', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat}),
     'dcterms:modified': new DateXform({tag: 'dcterms:modified', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat})
   }
@@ -87,6 +77,7 @@ utils.inherits(CoreXform, BaseXform, {
     this.map['cp:lastModifiedBy'].render(xmlStream, model.lastModifiedBy);
     this.map['cp:lastPrinted'].render(xmlStream, model.lastPrinted);
     this.map['cp:revision'].render(xmlStream, model.revision);
+    this.map['cp:contentStatus'].render(xmlStream, model.contentStatus);
     this.map['dcterms:created'].render(xmlStream, model.created);
     this.map['dcterms:modified'].render(xmlStream, model.modified);
 
@@ -137,6 +128,7 @@ utils.inherits(CoreXform, BaseXform, {
             lastModifiedBy: this.map['cp:lastModifiedBy'].model,
             lastPrinted: this.map['cp:lastPrinted'].model,
             revision: this.map['cp:revision'].model,
+            contentStatus: this.map['cp:contentStatus'].model,
             created: this.map['dcterms:created'].model,
             modified: this.map['dcterms:modified'].model
           };

--- a/spec/integration/workbook.spec.js
+++ b/spec/integration/workbook.spec.js
@@ -107,12 +107,13 @@ describe('Workbook', function() {
         });
     });
 
-    it('language and revision', function() {
+    it('language, revision and contentStatus', function() {
       var wb = new Excel.Workbook();
       var ws = wb.addWorksheet('Hello');
       ws.getCell('A1').value = 'World!';
       wb.language = 'Klingon';
       wb.revision = new Date(Date.UTC(2016,10,1,12));
+      wb.contentStauts = 'Final';
       return wb.xlsx.writeFile(TEST_XLSX_FILE_NAME)
         .then(function() {
           var wb2 = new Excel.Workbook();
@@ -121,6 +122,7 @@ describe('Workbook', function() {
         .then(function(wb2) {
           expect(wb2.language).to.equal(wb.language);
           expect(wb2.revision).to.equalDate(wb.revision);
+          expect(wb2.contentStatus).to.equal(wb.contentStatus);
         });
     });
 

--- a/spec/unit/xlsx/xform/core/core-xform.spec.js
+++ b/spec/unit/xlsx/xform/core/core-xform.spec.js
@@ -39,6 +39,14 @@ var expectations = [
     xml: fs.readFileSync(__dirname + '/data/core.03.xml').toString().replace(/\r\n/g, '\n'),
     get parsedModel() { return this.preparedModel; },
     tests: ['render', 'renderIn', 'parse']
+  },
+  {
+    title: 'core.xml - with cp:contentStatus',
+    create:  function() { return new CoreXform()},
+    preparedModel: { creator: 'Guyon Roche', lastModifiedBy: 'Guyon Roche', contentStatus: 'Final', created: new Date('2016-04-20T16:26:46Z'), modified: new Date('2016-05-12T06:52:49Z')},
+    xml: fs.readFileSync(__dirname + '/data/core.04.xml').toString().replace(/\r\n/g, '\n'),
+    get parsedModel() { return this.preparedModel; },
+    tests: ['render', 'renderIn', 'parse']
   }
 ];
 

--- a/spec/unit/xlsx/xform/core/data/core.04.xml
+++ b/spec/unit/xlsx/xform/core/data/core.04.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+                   xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <dc:creator>Guyon Roche</dc:creator>
+    <cp:lastModifiedBy>Guyon Roche</cp:lastModifiedBy>
+    <cp:contentStatus>Final</cp:contentStatus>
+    <dcterms:created xsi:type="dcterms:W3CDTF">2016-04-20T16:26:46Z</dcterms:created>
+    <dcterms:modified xsi:type="dcterms:W3CDTF">2016-05-12T06:52:49Z</dcterms:modified>
+</cp:coreProperties>


### PR DESCRIPTION
This adds support for cp:contentStatus, which previously resulted in an Excel file with this core property set to fail to load.