### PR TITLE
Fix Valid characters in XML (allow \n and \r when saving)

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -93,7 +93,7 @@ var utils = module.exports = {
     return path.path + '/_rels/' + path.name + '.rels';
   },
   xmlEncode: function(text) {
-    return text.replace(/[<>&'"\x7F\x00-\x1F]/g, function (c) {
+    return text.replace(/[<>&'"\x7F\x00-\x08\x0A-\x0C\x0E-\x1F]/g, function (c) {
       switch (c) {
         case '<': return '&lt;';
         case '>': return '&gt;';


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Valid_characters_in_XML - the previous PR (#262) stripped out the valid newline (\x09) and carriage return (\x0D) characters, although the test spec was correct.
Fix #207
Fix #274