### PR TITLE
Support error references in cell ranges

### DIFF
--- a/lib/utils/col-cache.js
+++ b/lib/utils/col-cache.js
@@ -165,10 +165,10 @@ var colCache = module.exports = {
 
   // convert [sheetName!][$]col[$]row[[$]col[$]row] into address or range structures
   decodeEx: function(value) {
-    var groups = value.match(/((('(([^']|'')*)')|([^'^ ^!]*))!)?(.*)/);
+    var groups = value.match(/(?:(?:(?:'((?:[^']|'')*)')|([^'^ ^!]*))!)?(.*)/);
 
-    var sheetName = groups[4] || groups[6];
-    var reference = groups[7];
+    var sheetName = groups[1] || groups[2]; // Qouted and unqouted groups
+    var reference = groups[3]; // Remaining address
 
     var parts = reference.split(':');
     if (parts.length > 1) {

--- a/lib/utils/col-cache.js
+++ b/lib/utils/col-cache.js
@@ -165,15 +165,12 @@ var colCache = module.exports = {
 
   // convert [sheetName!][$]col[$]row[[$]col[$]row] into address or range structures
   decodeEx: function(value) {
-    var sheetName;
+    var groups = value.match(/((('(([^']|'')*)')|([^'^ ^!]*))!)?(.*)/);
 
-    var parts = value.split('!');
-    if (parts.length > 1) {
-      value = parts.pop();
-      sheetName = parts.join('!').replace(/^'|'$/g, '');
-    }
+    var sheetName = groups[4] || groups[6];
+    var reference = groups[7];
 
-    parts = value.split(':');
+    var parts = reference.split(':');
     if (parts.length > 1) {
       var tl = this.decodeAddress(parts[0]);
       var br = this.decodeAddress(parts[1]);
@@ -192,8 +189,10 @@ var colCache = module.exports = {
         br: { address: br, col: right, row: bottom, $col$row: '$' + this.n2l(right) + '$' + bottom, sheetName: sheetName },
         dimensions: tl + ':' + br
       };
+    } else if (reference.startsWith('#')) {
+      return sheetName ? {sheetName: sheetName, error: reference} : {error: reference};
     } else {
-      var address = this.decodeAddress(value);
+      var address = this.decodeAddress(reference);
       return sheetName ? Object.assign({sheetName: sheetName}, address) : address;
     }
   },

--- a/spec/unit/utils/col-cache.spec.js
+++ b/spec/unit/utils/col-cache.spec.js
@@ -72,6 +72,7 @@ describe('colCache', function() {
       expect(colCache.decodeEx('Sheet1!$H$1')).to.deep.equal({'$col$row':'$H$1', address:'H1', col:8, row:1, sheetName:'Sheet1'});
       expect(colCache.decodeEx("'Sheet 1'!$H$1")).to.deep.equal({'$col$row':'$H$1', address:'H1', col:8, row:1, sheetName:'Sheet 1'});
       expect(colCache.decodeEx("'Sheet !$:1'!$H$1")).to.deep.equal({'$col$row':'$H$1', address:'H1', col:8, row:1, sheetName:'Sheet !$:1'});
+      expect(colCache.decodeEx("'Sheet !$:1'!#REF!")).to.deep.equal({sheetName:'Sheet !$:1', error:'#REF!'});
     });
   });
 


### PR DESCRIPTION
This PR adds support for decoding references with an error. It does this by using a regex to find the sheetname, if any, and handle the optional quotes. I wish JS regex had named groups, in which case this would be a bit nicer.