### PR TITLE
Avoid error on anchor with no media

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -284,12 +284,14 @@ utils.inherits(WorkSheetXform, BaseXform, {
         var drawingName = match[1];
         var drawing = options.drawings[drawingName];
         drawing.anchors.forEach(anchor => {
-          var image = {
-            type: 'image',
-            imageId: anchor.medium.index,
-            range: anchor.range,
-          };
-          model.media.push(image);
+          if (anchor.medium) {
+            var image = {
+              type: 'image',
+              imageId: anchor.medium.index,
+              range: anchor.range,
+            };
+            model.media.push(image);
+          }
         });
       }
     }


### PR DESCRIPTION
We ran into an error on a specific sheet from a customer, where it failed because `medium` was undefined. This fixes it as such, but I am not sure it is the right way to handle it.

I also coulnd't figure out how best to add a test for this.