### PR TITLE
Don’t set address if hyperlink r:id is undefined

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -262,7 +262,9 @@ utils.inherits(WorkSheetXform, BaseXform, {
       return h;
     }, {});
     options.hyperlinkMap = (model.hyperlinks || []).reduce(function(h, hyperlink) {
-      h[hyperlink.address] = rels[hyperlink.rId].Target;
+      if (hyperlink.rId) {
+        h[hyperlink.address] = rels[hyperlink.rId].Target;
+      }
       return h;
     }, {});
     options.formulae = {};


### PR DESCRIPTION
I found a sheet that didn't have an r:id set for a linked range, which caused it to fail. This simply ignores hyperlinks with no r:id for the hyperlinkMap