### PR TITLE
Fix right to left issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Each view also supports various properties:
 | Name              | Default   | Description |
 | ----------------- | --------- | ----------- |
 | state             | 'normal'  | Controls the view state - one of normal, frozen or split |
+| rtl        | false | Sets the worksheet view's orientation to right-to-left |
 | activeCell        | undefined | The currently selected cell |
 | showRuler         | true      | Shows or hides the ruler in Page Layout |
 | showRowColHeaders | true      | Shows or hides the row and column headers (e.g. A1, B1 at the top and 1,2,3 on the left |

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Each view also supports various properties:
 | Name              | Default   | Description |
 | ----------------- | --------- | ----------- |
 | state             | 'normal'  | Controls the view state - one of normal, frozen or split |
-| rtl        | false | Sets the worksheet view's orientation to right-to-left |
+| rightToLeft       | false     | Sets the worksheet view's orientation to right-to-left |
 | activeCell        | undefined | The currently selected cell |
 | showRuler         | true      | Shows or hides the ruler in Page Layout |
 | showRowColHeaders | true      | Shows or hides the row and column headers (e.g. A1, B1 at the top and 1,2,3 on the left |

--- a/lib/doc/enums.js
+++ b/lib/doc/enums.js
@@ -39,8 +39,8 @@ module.exports = {
     Xlsx: 1,
   },
   ReadingOrder: {
-    RightToLeft: 1,
-    LeftToRight: 2,
+    LeftToRight: 1,
+    RightToLeft: 2,
   },
   ErrorValue: {
     NotApplicable: '#N/A',

--- a/lib/xlsx/xform/sheet/sheet-view-xform.js
+++ b/lib/xlsx/xform/sheet/sheet-view-xform.js
@@ -43,6 +43,7 @@ utils.inherits(SheetViewXform, BaseXform, {
         xmlStream.addAttribute(name, value);
       }
     };
+    add('rightToLeft', '1', model.rtl === true);
     add('tabSelected', '1', model.tabSelected);
     add('showRuler', '0', model.showRuler === false);
     add('showRowColHeaders', '0', model.showRowColHeaders === false);

--- a/lib/xlsx/xform/sheet/sheet-view-xform.js
+++ b/lib/xlsx/xform/sheet/sheet-view-xform.js
@@ -43,7 +43,7 @@ utils.inherits(SheetViewXform, BaseXform, {
         xmlStream.addAttribute(name, value);
       }
     };
-    add('rightToLeft', '1', model.rtl === true);
+    add('rightToLeft', '1', model.rightToLeft === true);
     add('tabSelected', '1', model.tabSelected);
     add('showRuler', '0', model.showRuler === false);
     add('showRowColHeaders', '0', model.showRowColHeaders === false);
@@ -111,6 +111,7 @@ utils.inherits(SheetViewXform, BaseXform, {
       case 'sheetView':
         this.sheetView = {
           workbookViewId: parseInt(node.attributes.workbookViewId, 10),
+          rightToLeft: node.attributes.rightToLeft === '1',
           tabSelected: node.attributes.tabSelected === '1',
           showRuler: !(node.attributes.showRuler === '0'),
           showRowColHeaders: !(node.attributes.showRowColHeaders === '0'),
@@ -151,6 +152,7 @@ utils.inherits(SheetViewXform, BaseXform, {
         if (this.sheetView && this.pane) {
           model = this.model = {
             workbookViewId: this.sheetView.workbookViewId,
+            rightToLeft: this.sheetView.rightToLeft,
             state: VIEW_STATES[this.pane.state] || 'split', // split is default
             xSplit: this.pane.xSplit,
             ySplit: this.pane.ySplit,
@@ -174,6 +176,7 @@ utils.inherits(SheetViewXform, BaseXform, {
         } else {
           model = this.model = {
             workbookViewId: this.sheetView.workbookViewId,
+            rightToLeft: this.sheetView.rightToLeft,
             state: 'normal',
             showRuler: this.sheetView.showRuler,
             showRowColHeaders: this.sheetView.showRowColHeaders,

--- a/lib/xlsx/xform/style/alignment-xform.js
+++ b/lib/xlsx/xform/style/alignment-xform.js
@@ -55,15 +55,12 @@ var validation = {
     value = utils.validInt(value);
     return Math.max(0, value);
   },
-  readingOrderValues: [
-    {k: 'rtl', v: 2},
-    {k: 'ltr', v: 1},
-    {k: Enums.ReadingOrder.RightToLeft, v: 2},
-    {k: Enums.ReadingOrder.LeftToRight, v: 1}
-  ].reduce((p, v) => { p[v.k] = v.v; return p; }, {}),
-
   readingOrder: function(value) {
-    return this.readingOrderValues[value];
+    switch (value) {
+      case 'ltr': return Enums.ReadingOrder.LeftToRight;
+      case 'rtl': return Enums.ReadingOrder.RightToLeft;
+      default: return undefined;
+    }
   }
 };
 
@@ -155,7 +152,7 @@ utils.inherits(AlignmentXform, BaseXform, {
     add(node.attributes.shrinkToFit, 'shrinkToFit', !!node.attributes.shrinkToFit);
     add(node.attributes.indent, 'indent', parseInt(node.attributes.indent, 10));
     add(node.attributes.textRotation, 'textRotation', textRotationXform.toModel(node.attributes.textRotation));
-    add(node.attributes.readingOrder, 'readingOrder', node.attributes.readingOrder);
+    add(node.attributes.readingOrder, 'readingOrder', node.attributes.readingOrder === '2' ? 'rtl' : 'ltr');
     
     this.model = valid ? model : null;
   },

--- a/lib/xlsx/xform/style/alignment-xform.js
+++ b/lib/xlsx/xform/style/alignment-xform.js
@@ -56,10 +56,10 @@ var validation = {
     return Math.max(0, value);
   },
   readingOrderValues: [
-    {k: 'r2l', v: 1},
-    {k: 'l2r', v: 2},
-    {k: Enums.ReadingOrder.RightToLeft, v: 1},
-    {k: Enums.ReadingOrder.LeftToRight, v: 2}
+    {k: 'rtl', v: 2},
+    {k: 'ltr', v: 1},
+    {k: Enums.ReadingOrder.RightToLeft, v: 2},
+    {k: Enums.ReadingOrder.LeftToRight, v: 1}
   ].reduce((p, v) => { p[v.k] = v.v; return p; }, {}),
 
   readingOrder: function(value) {

--- a/spec/unit/xlsx/xform/sheet/data/sheet.1.3.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.1.3.json
@@ -5,7 +5,16 @@
     "tabColor": {"argb": "FF00FF00"},
     "outlineLevelCol": 0, "outlineLevelRow": 0
   },
-  "views": [{"state": "normal", "showRuler": true, "showGridLines": true, "showRowColHeaders": true, "zoomScale": 100, "zoomScaleNormal": 100, "workbookViewId": 0}],
+  "views": [{
+    "state": "normal",
+    "showRuler": true,
+    "showGridLines": true,
+    "showRowColHeaders": true,
+    "zoomScale": 100,
+    "zoomScaleNormal": 100,
+    "workbookViewId": 0,
+    "rightToLeft": false
+  }],
   "pageSetup": {
     "margins": {"left": 0.7, "right": 0.7, "top": 0.75, "bottom": 0.75, "header": 0.3, "footer":  0.3 },
     "firstPageNumber": 5, "useFirstPageNumber": true, "usePrinterDefaults": true, "copies": 3,

--- a/spec/unit/xlsx/xform/sheet/sheet-view-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/sheet-view-xform.spec.js
@@ -13,7 +13,7 @@ var expectations = [
     xml: '<sheetView workbookViewId="0">' +
            '<selection activeCell="G4" sqref="G4"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -23,7 +23,7 @@ var expectations = [
     xml: '<sheetView workbookViewId="0" zoomScale="60" zoomScaleNormal="80">' +
            '<selection activeCell="G4" sqref="G4"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 60, zoomScaleNormal: 80},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 60, zoomScaleNormal: 80},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -33,7 +33,7 @@ var expectations = [
     xml: '<sheetView workbookViewId="0" showRuler="0" showGridLines="0" showRowColHeaders="0">' +
            '<selection activeCell="G4" sqref="G4"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: false, showGridLines: false, showRowColHeaders: false, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'normal', activeCell: 'G4', showRuler: false, showGridLines: false, showRowColHeaders: false, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -43,7 +43,7 @@ var expectations = [
     xml: '<sheetView workbookViewId="0" view="pageBreakPreview">' +
            '<selection activeCell="G4" sqref="G4"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100, style: 'pageBreakPreview'},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100, style: 'pageBreakPreview'},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -54,7 +54,7 @@ var expectations = [
            '<pane xSplit="1234" ySplit="3456" topLeftCell="C3" activePane="bottomRight"/>' +
            '<selection pane="bottomRight" activeCell="B1" sqref="B1"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'B1', activePane: 'bottomRight', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'B1', activePane: 'bottomRight', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -65,7 +65,7 @@ var expectations = [
            '<pane xSplit="1234" ySplit="3456" topLeftCell="C3"/>' +
            '<selection activeCell="A1" sqref="A1"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'A1', activePane: 'topLeft', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'split', xSplit: 1234, ySplit: 3456, topLeftCell: 'C3', activeCell: 'A1', activePane: 'topLeft', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -76,7 +76,7 @@ var expectations = [
            '<pane xSplit="2" ySplit="3" topLeftCell="C4" activePane="bottomRight" state="frozen"/>' +
            '<selection pane="bottomRight" activeCell="D5" sqref="D5"/>' +
          '</sheetView>',
-    parsedModel: {workbookViewId: 0, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+    parsedModel: {workbookViewId: 0, rightToLeft: false, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   },
   {
@@ -96,9 +96,17 @@ var expectations = [
            '</sheetView>' +
          '</sheetViews>',
     parsedModel: [
-      {workbookViewId: 0, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
-      {workbookViewId: 1, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100}
+      {workbookViewId: 0, rightToLeft: false, state: 'normal', activeCell: 'G4', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
+      {workbookViewId: 1, rightToLeft: false, state: 'frozen', xSplit: 2, ySplit: 3, topLeftCell: 'C4', activeCell: 'D5', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100}
     ],
+    tests: ['render', 'renderIn', 'parse']
+  },
+  {
+    title: 'Right To Left',
+    create: () => new SheetViewXform(),
+    preparedModel: {rightToLeft: true},
+    xml: '<sheetView workbookViewId="0" rightToLeft="1"></sheetView>',
+    parsedModel: {workbookViewId: 0, rightToLeft: true, state: 'normal', showRuler: true, showGridLines: true, showRowColHeaders: true, zoomScale: 100, zoomScaleNormal: 100},
     tests: ['render', 'renderIn', 'parse']
   }
 ];

--- a/spec/unit/xlsx/xform/style/alignment-xform.spec.js
+++ b/spec/unit/xlsx/xform/style/alignment-xform.spec.js
@@ -156,6 +156,22 @@ var expectations = [
     tests: ['render', 'renderIn', 'parse']
   },
   {
+    title: 'Reading Order [Left To Right]',
+    create: () => new AlignmentXform(),
+    preparedModel: { readingOrder: 'ltr' },
+    xml: '<alignment readingOrder="1"/>',
+    get parsedModel() { return this.preparedModel; },
+    tests: ['render', 'renderIn', 'parse']
+  },
+  {
+    title: 'Reading Order [Right To Left]',
+    create: () => new AlignmentXform(),
+    preparedModel: { readingOrder: 'rtl' },
+    xml: '<alignment readingOrder="2"/>',
+    get parsedModel() { return this.preparedModel; },
+    tests: ['render', 'renderIn', 'parse']
+  },
+  {
     title: 'Vertical Text',
     create: () => new AlignmentXform(),
     preparedModel: { horizontal: 'right', vertical: 'bottom', textRotation: 'vertical' },


### PR DESCRIPTION
Adds a new property to sheet view. And fixes `readingOrder` as it wasn't doing anything for 2 reasons:

1. The values were set wrong. 
2. The keys were `l2r` and `r2l` instead of the document `ltr` and `rtl` ones.

Closes #72
Closes #126