### PR TITLE
Guard null model fields - fix and tests

### DIFF
--- a/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
@@ -106,14 +106,16 @@ utils.inherits(TwoCellAnchorXform, BaseXform, {
   },
 
   reconcile: function(model, options) {
-    var rel = options.rels[model.picture.rId];
-    var match = rel.Target.match(/.*\/media\/(.+[.][a-z]{3,4})/);
-    if (match) {
-      var name = match[1];
-      var mediaId = options.mediaIndex[name];
-      model.medium = options.media[mediaId];
+    if (model.picture && model.picture.rId) {
+      var rel = options.rels[model.picture.rId];
+      var match = rel.Target.match(/.*\/media\/(.+[.][a-z]{3,4})/);
+      if (match) {
+        var name = match[1];
+        var mediaId = options.mediaIndex[name];
+        model.medium = options.media[mediaId];
+      }
     }
-    if (Number.isInteger(model.tl.row) && Number.isInteger(model.tl.col) && Number.isInteger(model.br.row) && Number.isInteger(model.br.col)) {
+    if (model.tl && Number.isInteger(model.tl.row) && Number.isInteger(model.tl.col) && Number.isInteger(model.br.row) && Number.isInteger(model.br.col)) {
       model.range = colCache.encode(model.tl.row + 1, model.tl.col + 1, model.br.row, model.br.col);
     } else {
       model.range = {

--- a/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
@@ -115,7 +115,7 @@ utils.inherits(TwoCellAnchorXform, BaseXform, {
         model.medium = options.media[mediaId];
       }
     }
-    if (model.tl && Number.isInteger(model.tl.row) && Number.isInteger(model.tl.col) && Number.isInteger(model.br.row) && Number.isInteger(model.br.col)) {
+    if (model.tl && model.br && Number.isInteger(model.tl.row) && Number.isInteger(model.tl.col) && Number.isInteger(model.br.row) && Number.isInteger(model.br.col)) {
       model.range = colCache.encode(model.tl.row + 1, model.tl.col + 1, model.br.row, model.br.col);
     } else {
       model.range = {

--- a/spec/unit/xlsx/xform/drawing/two-cell-anchor-xform.spec.js
+++ b/spec/unit/xlsx/xform/drawing/two-cell-anchor-xform.spec.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var fs = require('fs');
+var chai = require('chai');
+var expect = chai.expect;
+
+var TwoCellAnchorXform = require('../../../../../lib/xlsx/xform/drawing/two-cell-anchor-xform');
+
+
+describe('TwoCellAnchorXform', function() {
+  describe('reconcile', function() {
+    it('should not throw on null picture', function() {
+      var twoCell = new TwoCellAnchorXform();
+      expect(twoCell.reconcile({picture: null}, {})).to.not.throw;
+    });
+    it('should not throw on null tl', function() {
+      var twoCell = new TwoCellAnchorXform();
+      expect(twoCell.reconcile({tl: null}, {})).to.not.throw;
+    });
+  });
+});

--- a/spec/unit/xlsx/xform/drawing/two-cell-anchor-xform.spec.js
+++ b/spec/unit/xlsx/xform/drawing/two-cell-anchor-xform.spec.js
@@ -15,7 +15,11 @@ describe('TwoCellAnchorXform', function() {
     });
     it('should not throw on null tl', function() {
       var twoCell = new TwoCellAnchorXform();
-      expect(twoCell.reconcile({tl: null}, {})).to.not.throw;
+      expect(twoCell.reconcile({br: {col: 1, row: 1}}, {})).to.not.throw;
+    });
+    it('should not throw on null br', function() {
+      var twoCell = new TwoCellAnchorXform();
+      expect(twoCell.reconcile({tl: {col: 1, row: 1}}, {})).to.not.throw;
     });
   });
 });


### PR DESCRIPTION
I ran into an issue with the [`reconcile` method](https://github.com/guyonroche/exceljs/blob/master/lib/xlsx/xform/drawing/two-cell-anchor-xform.js#L108) of `TwoCellAnchorXform`. I can't provide the spreadsheet to give you a working demo of the issue, but I did find the problem and built a unit test to display the issue. Basically, `model.picture` might be null, which throws an error. Once I added the guards, I was able to load the workbook as usual.