### PR TITLE
Crude fix for skipping empty rows, avoiding high memory usage

### DIFF
--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -80,6 +80,20 @@ utils.inherits(RowXform, BaseXform, {
       this.parser.parseOpen(node);
       return true;
     } else if (node.name === 'row') {
+      if (node.isSelfClosing) {
+        // We've seen some files that have up to a ~a million trailing rows
+        // that only seem to exist as placeholders for custom formats, eg.:
+        //
+        //   <row r="1047685" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+        //   <row r="1047686" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+        //
+        // Avoid spending memory on those rows by skipping them as soon as we
+        // notice that the XML tag is self-closing, and thus cannot contain any
+        // data we're interested in. For one file in particular,
+        // this made the peak utilized JavaScript heap go from 123 MB to 13 MB:
+
+        return false;
+      }
       var spans = node.attributes.spans ? node.attributes.spans.split(':').map(function(span) { return parseInt(span, 10); }) : [undefined, undefined];
       var model = this.model = {
         number: parseInt(node.attributes.r, 10),


### PR DESCRIPTION
Addresses: https://podio.com/peakon/operations/apps/actions/items/81?utm_campaign=member_reference_add

This hack avoids the excessive memory usage when processing the particular file that caused the October 4th OOM incident. Turns out the `xl/worksheets/sheet1.xml` entry inside it actually contains about a million trailing empty rows, and indeed materializing that as row objects was what was causing the memory problem.

Since the main worksheet XML file unzips to 70 MB, there's still a significant processing time associated with running it through the SAX parser. On my laptop this fix brings down the processing time from ~20 to ~16 seconds. We might be able to do better than that by eg. discarding the rest of the file when we've seen a certain number of consecutive empty rows.

Needless to say, I'm not completely happy with the way this is integrated -- as a minimum it should probably go behind a mode switch of some kind. I can look into that if y'all agree with the overall approach.

@holm, I'm assuming that omitting empty rows occurring between populated rows won't have any adverse effects on the import itself?

Thoughts?