### PR TITLE
Don't break when docProps/core.xml contains a <cp:version> tag

### DIFF
--- a/lib/xlsx/xform/core/core-xform.js
+++ b/lib/xlsx/xform/core/core-xform.js
@@ -25,6 +25,7 @@ var CoreXform = module.exports = function() {
     'cp:lastModifiedBy': new StringXform({tag: 'cp:lastModifiedBy'}),
     'cp:lastPrinted': new DateXform({tag: 'cp:lastPrinted', format: CoreXform.DateFormat}),
     'cp:revision': new DateXform({tag: 'cp:revision'}),
+    'cp:version': new StringXform({tag: 'cp:version'}),
     'cp:contentStatus': new StringXform({tag: 'cp:contentStatus'}),
     'dcterms:created': new DateXform({tag: 'dcterms:created', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat}),
     'dcterms:modified': new DateXform({tag: 'dcterms:modified', attrs: CoreXform.DateAttrs, format: CoreXform.DateFormat})
@@ -61,6 +62,7 @@ utils.inherits(CoreXform, BaseXform, {
     this.map['cp:lastModifiedBy'].render(xmlStream, model.lastModifiedBy);
     this.map['cp:lastPrinted'].render(xmlStream, model.lastPrinted);
     this.map['cp:revision'].render(xmlStream, model.revision);
+    this.map['cp:version'].render(xmlStream, model.version);
     this.map['cp:contentStatus'].render(xmlStream, model.contentStatus);
     this.map['dcterms:created'].render(xmlStream, model.created);
     this.map['dcterms:modified'].render(xmlStream, model.modified);


### PR DESCRIPTION
I've run into an .xlsx that contains a `<cp:version>` tag in `docProps/core.xml`:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dc:title>...</dc:title><dc:creator>...</dc:creator><cp:lastModifiedBy>...</cp:lastModifiedBy><cp:lastPrinted>2017-05-15T16:17:00Z</cp:lastPrinted><dcterms:created xsi:type="dcterms:W3CDTF">2015-07-15T16:27:34Z</dcterms:created><dcterms:modified xsi:type="dcterms:W3CDTF">2017-09-06T15:39:12Z</dcterms:modified><cp:version></cp:version></cp:coreProperties>
```

This made exceljs break with:

```
Unexpected xml node in parseOpen: {"name":"cp:version","attributes":{},"isSelfClosing":false}
```

This PR fixes that by providing a parser for that property.

I would have liked to include a regression test with an actual LibreOffice document, but the most recent version of LibreOffice doesn't seem to include the tag, and I'm unable to share the spreadsheet that actually caused the problem as it includes sensitive data.