### PR TITLE
 fix #79 outdated dependencies in unzip2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "moment": "2.19.3",
     "promish": ">=5.0.2",
     "sax": "^1.2.2",
-    "unzip2": "^0.2.5"
+    "unzip2": "git+ssh://git@github.com/sveinburne/node-unzip-2.git"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.0",


### PR DESCRIPTION
This is a workaround unmaintained unzip2 package.
Upstream custom package [`sveinburne/unzip2`](https://github.com/sveinburne/node-unzip-2) tests passed with upgraded dependencies.
Passed this package tests too.

New dependency graph for unzip2: 
``` json
{
    "binary": "^0.3.0",
    "fstream": "^1.0.11",
    "match-stream": "0.0.2",
    "pullstream": "^0.4.1",
    "readable-stream": "^2.3.3",
    "setimmediate": "^1.0.5"
},
```