### PR TITLE
Round Excel date to nearest millisecond when converting to javascript date

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -64,7 +64,8 @@ var utils = module.exports = {
     return 25569 + (d.getTime() / (24 * 3600 * 1000)) - (date1904 ? 1462 : 0);
   },
   excelToDate: function(v, date1904) {
-    return new Date((v - 25569 + (date1904 ? 1462 : 0)) * 24 * 3600 * 1000);
+    var millisecondSinceEpoch = Math.round((v - 25569 + (date1904 ? 1462 : 0)) * 24 * 3600 * 1000);
+    return new Date(millisecondSinceEpoch);
   },
   parsePath: function(filepath) {
     var last = filepath.lastIndexOf('/');

--- a/spec/unit/utils/utils.spec.js
+++ b/spec/unit/utils/utils.spec.js
@@ -39,4 +39,33 @@ describe('utils', function() {
       });
     });
   });
+
+  describe('dateToExcel', function() {
+    it('should convert date to excel properly', function() {
+      const myDate = new Date(Date.UTC(2017, 11, 15, 17, 0, 0, 0));
+    
+      const excelDate = utils.dateToExcel(myDate, false);
+
+      expect(excelDate).to.equal(43084.70833333333);
+    });
+  });
+
+  describe('excelToDate', function() {
+    it('should round to the nearest millisecond when parsing excel date', function() {
+      const myDate = new Date(Date.UTC(2017, 11, 15, 17, 0, 0, 0));
+      const excelDate = utils.dateToExcel(myDate, false);
+      
+      const dateConverted = utils.excelToDate(excelDate, false);
+
+      expect(dateConverted).to.deep.equal(myDate);
+    });
+    it('should not lost millisecond precision when parsing excel date', function() {
+      const myDate = new Date(Date.UTC(2017, 11, 15, 17, 0, 0, 0));
+      const excelDate = utils.dateToExcel(myDate, false);
+      
+      const dateConverted = utils.excelToDate(excelDate, false);
+
+      expect(dateConverted).to.deep.equal(myDate);
+    });
+  });
 });


### PR DESCRIPTION
Hi,

while I was trying to test the generation of our excel file using your library, I found out that some date were not matching what I was expecting.

Opening my file in excel seem to display the correct value, but reloading it with the library and then comparing the excel value to what I was expecting was not always matching. By example writing the following date 2017-11-15T17:00:00.000Z to an excel file and then re-reading it would return 2017-11-15T16:59:59.999Z.

Since excel already round value to the millisecond when showing the value and a javascript date doesn't have precision under a millisecond, I would like to propose that we round the value to the nearest millisecond when reading an excel file.

I haven't found any mention of precision in the spec file, but I think it would be better than truncating the value as it would at least keep the same value when writing and reading a file.