### PR TITLE
Bug fix: wb.worksheets/wb.eachSheet caused getWorksheet(0) to return sheet

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -109,11 +109,11 @@ Workbook.prototype = {
 
   get worksheets() {
     // return a clone of _worksheets
-    return this._worksheets.sort((a, b) => a.orderNo - b.orderNo).filter(Boolean);
+    return this._worksheets.slice(1).sort((a, b) => a.orderNo - b.orderNo).filter(Boolean);
   },
 
   eachSheet: function(iteratee) {
-    this._worksheets.sort((a, b) => a.orderNo - b.orderNo).forEach((sheet) => {
+    this._worksheets.slice(1).sort((a, b) => a.orderNo - b.orderNo).forEach((sheet) => {
       iteratee(sheet, sheet.id);
     });
   },
@@ -153,7 +153,7 @@ Workbook.prototype = {
       modified: this.modified,
       properties: this.properties,
       worksheets: this._worksheets.filter(Boolean).map(function(worksheet) { return worksheet.model; }),
-      sheets: this._worksheets.sort((a, b) => a.orderNo - b.orderNo).map(ws => ws.model).filter(Boolean),
+      sheets: this._worksheets.slice(1).sort((a, b) => a.orderNo - b.orderNo).map(ws => ws.model).filter(Boolean),
       definedNames: this._definedNames.model,
       views: this.views,
       company: this.company,

--- a/spec/unit/doc/workbook.spec.js
+++ b/spec/unit/doc/workbook.spec.js
@@ -118,4 +118,16 @@ describe('Workbook', function() {
     wb.addWorksheet('first');
     expect(wb.getWorksheet(0)).to.equal(undefined);
   });
+  
+  it('returns undefined for sheet 0 after accessing wb.worksheets or wb.eachSheet ', function() {
+    var wb = new Excel.Workbook();
+    var sheet = wb.addWorksheet('first');
+    
+    wb.eachSheet(function(){});
+    var numSheets = wb.worksheets.length;
+    
+    expect(numSheets).to.equal(1);
+    expect(wb.getWorksheet(0)).to.equal(undefined);
+    expect(wb.getWorksheet(1) === sheet).to.equal(true);
+  });
 });


### PR DESCRIPTION
wb._worksheets is an array with an empty first element. Calling wb.worksheets or wb.eachSheet called _worksheets.sort() which mutated the array and shifted the sheets into the empty element slot. I am not sure that the mutation was intentional or necessary. My solution no longer mutates _worksheets.

Also added test.