### PR TITLE
Add Node 8 and Node 9 to continuous integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 6
   - 7
   - 8
   - 9

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - 6
   - 7
+  - 8
+  - 9
 before_script:
   - npm run build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 6
   - 7
   - 8
   - 9


### PR DESCRIPTION
Hi @guyonroche,

I appreciate your work on this package! I use it regularly in different node environments, and I think using simple continuous integration would be very helpful for me (and possibly others) to understand this package's node compatibility, and for ensuring tests pass for pull requests and new features.

In a [previous PR](https://github.com/guyonroche/exceljs/pull/453) I've added a `.travis.yml` file that TravisCI can use. It's free of charge, and the good news is that the [tests pass in Node versions 6-9](https://travis-ci.org/cooltoast/exceljs/)!

Please consider activating this repo in TravisCI: https://docs.travis-ci.com/user/getting-started/
Upon the next pushed commit, it'll immediately build and run the tests you've written.

Thanks!