### PR TITLE
Add support for inlineStr, including rich text

### DIFF
--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -13,7 +13,6 @@ var Enums = require('../../../doc/enums');
 var Range = require('../../../doc/range');
 
 var RichTextXform = require('../strings/rich-text-xform');
-var richTextXForm = new RichTextXform();
 
 function getValueType(v) {
   if ((v === null) || (v === undefined)) {
@@ -47,6 +46,7 @@ function getEffectiveCellType(cell) {
 
 
 var CellXform = module.exports = function() {
+  this.richTextXForm = new RichTextXform();
 };
 
 utils.inherits(CellXform, BaseXform, {
@@ -196,8 +196,9 @@ utils.inherits(CellXform, BaseXform, {
           if (model.value && model.value.richText) {
             xmlStream.addAttribute('t', 'inlineStr');
             xmlStream.openNode('is');
+            var self = this;
             model.value.richText.forEach(function(text) {
-              richTextXForm.render(xmlStream, text);
+              self.richTextXForm.render(xmlStream, text);
             });
             xmlStream.closeNode('is');
           } else {
@@ -271,7 +272,7 @@ utils.inherits(CellXform, BaseXform, {
         return true;
 
       case 'r':
-        this.parser = richTextXForm;//this.map.r;
+        this.parser = this.richTextXForm;
         this.parser.parseOpen(node);
         return true;
 

--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -12,6 +12,8 @@ var BaseXform = require('../base-xform');
 var Enums = require('../../../doc/enums');
 var Range = require('../../../doc/range');
 
+var RichTextXform = require('../strings/rich-text-xform');
+var richTextXForm = new RichTextXform();
 
 function getValueType(v) {
   if ((v === null) || (v === undefined)) {
@@ -191,8 +193,17 @@ utils.inherits(CellXform, BaseXform, {
           xmlStream.addAttribute('t', 's');
           xmlStream.leafNode('v', null, model.ssId);
         } else {
-          xmlStream.addAttribute('t', 'str');
-          xmlStream.leafNode('v', null, model.value);
+          if (model.value && model.value.richText) {
+            xmlStream.addAttribute('t', 'inlineStr');
+            xmlStream.openNode('is');
+            model.value.richText.forEach(function(text) {
+              richTextXForm.render(xmlStream, text);
+            });
+            xmlStream.closeNode('is');
+          } else {
+            xmlStream.addAttribute('t', 'str');
+            xmlStream.leafNode('v', null, model.value);
+          }
         }
         break;
 
@@ -224,8 +235,12 @@ utils.inherits(CellXform, BaseXform, {
 
     xmlStream.closeNode(); // </c>
   },
-  
+
   parseOpen: function(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
     switch (node.name) {
       case 'c':
         // var address = colCache.decodeAddress(node.attributes.r);
@@ -251,17 +266,35 @@ utils.inherits(CellXform, BaseXform, {
         this.currentNode = 'v';
         return true;
 
+      case 't':
+        this.currentNode = 't';
+        return true;
+
+      case 'r':
+        this.parser = richTextXForm;//this.map.r;
+        this.parser.parseOpen(node);
+        return true;
+
       default:
         return false;
     }
   },
   parseText: function(text) {
+    if (this.parser) {
+      this.parser.parseText(text);
+      return;
+    }
     switch (this.currentNode) {
       case 'f':
         this.model.formula = this.model.formula ? this.model.formula + text : text;
         break;
       case 'v':
-        this.model.value = this.model.value ? this.model.value + text : text;
+      case 't':
+        if (this.model.value && this.model.value.richText) {
+          this.model.value.richText.text = this.model.value.richText.text ? this.model.value.richText.text + text : text;
+        } else {
+          this.model.value = this.model.value ? this.model.value + text : text;
+        }
         break;
       default:
         break;
@@ -297,6 +330,9 @@ utils.inherits(CellXform, BaseXform, {
               model.type = Enums.ValueType.String;
               model.value = utils.xmlDecode(model.value);
               break;
+            case 'inlineStr':
+              model.type = Enums.ValueType.String;
+              break;
             case 'b':
               model.type = Enums.ValueType.Boolean;
               model.value = parseInt(model.value, 10) !== 0;
@@ -318,9 +354,29 @@ utils.inherits(CellXform, BaseXform, {
         return false;
       case 'f':
       case 'v':
+      case 'is':
+        this.currentNode = undefined;
+        return true;
+      case 't':
+        if (this.parser) {
+          this.parser.parseClose(name);
+          return true;
+        } else {
+          this.currentNode = undefined;
+          return true;
+        }
+      case 'r':
+        this.model.value = this.model.value || {};
+        this.model.value.richText = this.model.value.richText || [];
+        this.model.value.richText.push(this.parser.model);
+        this.parser = undefined;
         this.currentNode = undefined;
         return true;
       default:
+        if (this.parser) {
+          this.parser.parseClose(name);
+          return true;
+        }
         return false;
     }
   },
@@ -366,7 +422,7 @@ utils.inherits(CellXform, BaseXform, {
       default:
         break;
     }
-    
+
     // look for hyperlink
     var hyperlink = options.hyperlinkMap[model.address];
     if (hyperlink) {

--- a/spec/integration/workbook-xlsx-writer/workbook-xlsx-writer.spec.js
+++ b/spec/integration/workbook-xlsx-writer/workbook-xlsx-writer.spec.js
@@ -195,7 +195,6 @@ describe('WorkbookWriter', function() {
         })
         .then(function(wb2) {
           var ws2 = wb2.getWorksheet('Hello');
-          console.log('>>>', ws2.getCell('A1').value)
           expect(ws2.getCell('A1').value).to.deep.equal({
             richText: [
               {

--- a/spec/integration/workbook-xlsx-writer/workbook-xlsx-writer.spec.js
+++ b/spec/integration/workbook-xlsx-writer/workbook-xlsx-writer.spec.js
@@ -166,6 +166,50 @@ describe('WorkbookWriter', function() {
         });
     });
 
+    it('rich text', function() {
+      var options = {
+        filename: TEST_XLSX_FILE_NAME,
+        useStyles: true
+      };
+      var wb = new Excel.stream.xlsx.WorkbookWriter(options);
+      var ws = wb.addWorksheet('Hello');
+
+      ws.getCell('A1').value = {
+        richText: [
+          {
+            font: {color: {argb: 'FF0000'}}, text: 'red '
+          },
+          {
+            font: {color: {argb: '00FF00'}, bold: true}, text: ' bold green'
+          }
+        ]
+      };
+
+      ws.getCell('B1').value = 'plain text'
+
+      ws.commit();
+      return wb.commit()
+        .then(function() {
+          var wb2 = new Excel.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(function(wb2) {
+          var ws2 = wb2.getWorksheet('Hello');
+          console.log('>>>', ws2.getCell('A1').value)
+          expect(ws2.getCell('A1').value).to.deep.equal({
+            richText: [
+              {
+                font: {color: {argb: 'FF0000'}}, text: 'red '
+              },
+              {
+                font: {color: {argb: '00FF00'}, bold: true}, text: ' bold green'
+              }
+            ]
+          });
+          expect(ws2.getCell('B1').value).to.equal('plain text');
+        });
+    });
+
     it('A lot of sheets', function() {
       this.timeout(5000);
 

--- a/spec/unit/xlsx/xform/sheet/cell-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/cell-xform.spec.js
@@ -61,13 +61,33 @@ var expectations = [
     tests: ['render', 'renderIn', 'parse']
   },
   {
-    title: 'Inline String',
+    title: 'String',
     create: function() { return new CellXform(); },
     initialModel: {address: 'A1', type: Enums.ValueType.String, value: 'Foo'},
     preparedModel: {address: 'A1', type: Enums.ValueType.String, value: 'Foo'},
     xml: '<c r="A1" t="str"><v>Foo</v></c>',
     parsedModel: {address: 'A1', type: Enums.ValueType.String, value: 'Foo'},
     reconciledModel: {address: 'A1', type: Enums.ValueType.String, value: 'Foo'},
+    tests: ['prepare', 'render', 'renderIn', 'parse', 'reconcile'],
+    options: { hyperlinkMap: fakeHyperlinkMap, styles: fakeStyles }
+  },
+  {
+    title: 'Inline String with plain text',
+    create: function() { return new CellXform(); },
+    xml: '<c r="A1" t="inlineStr"><is><t>Foo</t></is></c>',
+    parsedModel: {address: 'A1', type: Enums.ValueType.String, value: 'Foo'},
+    reconciledModel: {address: 'A1', type: Enums.ValueType.String, value: 'Foo'},
+    tests: ['parse', 'reconcile'],
+    options: { hyperlinkMap: fakeHyperlinkMap, styles: fakeStyles }
+  },
+  {
+    title: 'Inline String with RichText',
+    create: function() { return new CellXform(); },
+    initialModel: {address: 'A1', type: Enums.ValueType.String, value: { richText: [ {font: {color: {argb: 'FF0000'}}, text: 'red'}, {font: {color: {argb: '00FF00'}}, text: 'green'} ] }},
+    preparedModel: {address: 'A1', type: Enums.ValueType.String, value: { richText: [ {font: {color: {argb: 'FF0000'}}, text: 'red'}, {font: {color: {argb: '00FF00'}}, text: 'green'} ] }},
+    xml: '<c r="A1" t="inlineStr"><is><r><rPr><color rgb="FF0000"/></rPr><t>red</t></r><r><rPr><color rgb="00FF00"/></rPr><t>green</t></r></is></c>',
+    parsedModel: {address: 'A1', type: Enums.ValueType.String, value: { richText: [ {font: {color: {argb: 'FF0000'}}, text: 'red'}, {font: {color: {argb: '00FF00'}}, text: 'green'} ] }},
+    reconciledModel: {address: 'A1', type: Enums.ValueType.RichText, value: { richText: [ {font: {color: {argb: 'FF0000'}}, text: 'red'}, {font: {color: {argb: '00FF00'}}, text: 'green'} ] }},
     tests: ['prepare', 'render', 'renderIn', 'parse', 'reconcile'],
     options: { hyperlinkMap: fakeHyperlinkMap, styles: fakeStyles }
   },


### PR DESCRIPTION
- When streaming, render "richText" values as <c t="inlineStr"><is><r>...</r></is></c>
- Parse inlineStr values correctly, including plain text and rich text

This should fix #409 and hopefully also covers the case in #495.