### PR TITLE
Include index.d.ts in published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "index.d.ts"
   ]
 }


### PR DESCRIPTION
This allows TypeScript to automatically detect the types based on the file.