### PR TITLE
Try to handle the case where a <c> element is missing an r attribute

### DIFF
--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -329,13 +329,30 @@ Row.prototype = {
       throw new Error('Invalid row number in model');
     }
     this._cells = [];
+    var previousAddress;
     value.cells.forEach(cellModel => {
       switch (cellModel.type) {
         case Cell.Types.Merge:
           // special case - don't add this types
           break;
         default:
-          var cell = this.getCellEx(colCache.decodeAddress(cellModel.address));
+          var address;
+          if (cellModel.address) {
+            address = colCache.decodeAddress(cellModel.address);
+          } else if (previousAddress) {
+            // This is a <c> element without an r attribute
+            // Assume that it's the cell for the next column
+            var row = previousAddress.row;
+            var col = previousAddress.col + 1;
+            address = {
+              row: row,
+              col: col,
+              address: colCache.encodeAddress(row, col),
+              $col$row: '$' + colCache.n2l(col) + '$' + row
+            };
+          }
+          previousAddress = address;
+          var cell = this.getCellEx(address);
           cell.model = cellModel;
           break;
       }


### PR DESCRIPTION
I've run into an Excel spreadsheet where some `<c>` elements do not have address references. It looks like it's some kind of shorthand where it's implicitly the next cell, and Excel opens the spreadsheet fine. Here's a pretty-printed snippet from the spreadsheet:

```xml
  <sheetData>
    <row r="1" spans="1:1" ht="18" customHeight="1">
      <c r="A1" s="1" t="s">
        <v>0</v>
      </c>
    </row>
    <row r="2" spans="1:1" ht="12.75" customHeight="1">
      <c r="A2" s="2" t="s">
        <v>1</v>
      </c>
    </row>
    <row r="3" spans="1:1" ht="12.75" customHeight="1">
      <c r="A3" s="2" t="s">
        <v>2</v>
      </c>
    </row>
    <row r="5" spans="1:12" ht="12.75" customHeight="1">
      <c r="A5" s="4" t="s">
        <v>51</v>
      </c>
      <c s="4" t="s">
        <v>52</v>
      </c>
      <c s="4" t="s">
        <v>53</v>
      </c>
      <c s="4" t="s">
        <v>54</v>
      </c>
      ...
```

Exceljs breaks with:

```
(node:3101) TypeError: Cannot read property 'match' of undefined
    at Object.decodeAddress (/Users/andreaslind/work/exceljs/lib/utils/col-cache.js:93:21)
    at value.cells.forEach.cellModel (/Users/andreaslind/work/exceljs/lib/doc/row.js:325:46)
    at Array.forEach (<anonymous>)
    at module.exports.set model [as model] (/Users/andreaslind/work/exceljs/lib/doc/row.js:319:17)
    at model.rows.forEach.rowModel (/Users/andreaslind/work/exceljs/lib/doc/worksheet.js:595:17)
    at Array.forEach (<anonymous>)
    at module.exports._parseRows (/Users/andreaslind/work/exceljs/lib/doc/worksheet.js:592:16)
    at module.exports.set model [as model] (/Users/andreaslind/work/exceljs/lib/doc/worksheet.js:606:10)
    at value.worksheets.forEach.worksheetModel (/Users/andreaslind/work/exceljs/lib/doc/workbook.js:197:23)
    at Array.forEach (<anonymous>)
```

(The line numbers might be off, as I'm currently running an older version, unfortunately)

I'm not sure the enclosed solution is per spec. Maybe someone else knows more?

And yes, it's actually the same spreadsheet that caused https://github.com/guyonroche/exceljs/pull/536 -- I'll follow up if I'm able to find out how it was generated.