### PR TITLE
Add dateUTC flag to CSV Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1363,6 +1363,8 @@ The CSV parser uses [fast-csv](https://www.npmjs.com/package/fast-csv) to write 
 
 Dates are formatted using the npm module [moment](https://www.npmjs.com/package/moment).
  If no dateFormat is supplied, moment.ISO_8601 is used.
+ When writing a CSV you can supply the boolean dateUTC as true to have ExcelJS parse the date without automatically
+ converting the timezone using `moment.utc()`.
 
 ### Streaming I/O
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1100,6 +1100,7 @@ export interface CsvReadOptions {
 
 export interface CsvWriteOptions {
 	dateFormat: string;
+	dateUTC: boolean;
 }
 
 export interface Csv {

--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -114,6 +114,7 @@ CSV.prototype = {
       csvStream.pipe(stream);
 
       var dateFormat = options.dateFormat;
+      var dateUTC = options.dateUTC;
       var map = options.map || (value => {
           if (value) {
             if (value.text || value.hyperlink) {
@@ -123,7 +124,7 @@ CSV.prototype = {
               return value.result || '';
             }
             if (value instanceof Date) {
-              return dateFormat ? moment(value).format(dateFormat) : moment(value).format();
+              return dateFormat ? dateUTC ? moment.utc(value).format(dateFormat) : moment(value).format(dateFormat) : moment(value).format();
             }
             if (value.error) {
               return value.error;


### PR DESCRIPTION
Hello! I am very excited to help contribute to this library as I have been a significant power user for the past year. I can only imagine how much hard work has gone into this.

The problem I had is that when I would create an Excel file with a date type field and write it out as CSV, Moment.js would parse it based on the user's local time. This meant that sometimes when formatting the date into a less verbose format, say (MM/DD/YYYY) it would be off by one day due to the timezone.

This pull request adds an option to the CSV writing module that allows for the user to override this functionality using the `moment.utc()` function. The advantage here is that less specific date formats (i.e. the cell is originally just MM/DD/YYYY) don't get parsed as the wrong date just because Excel defaults the time to 00:00; 

Adding the option may not be the best way to implement this feature but it fixed the issue I was having and hopefully can help alleviate some issues related to dates having unknown behavior.