### PR TITLE
Add CSV write buffer support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-/// <reference types="node" />
-
-import { Writable, Stream } from 'stream';
+declare interface Buffer { }
+declare interface Stream { }
+declare interface Writable { }
 
 export const enum RelationshipType {
 	None = 0,
@@ -1083,6 +1083,11 @@ export interface Xlsx {
 	createInputStream(): Writable;
 
 	/**
+	 * write to a buffer
+	 */
+	writeBuffer(): Promise<Buffer>;
+
+	/**
 	 * write to a file
 	 */
 	writeFile(path: string): Promise<void>;
@@ -1118,6 +1123,11 @@ export interface Csv {
 	 * Create input stream for reading
 	 */
 	createInputStream(): Writable;
+
+	/**
+	 * write to a buffer
+	 */
+	writeBuffer(): Promise<Buffer>;
 
 	/**
 	 * write to a file

--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -11,6 +11,7 @@ var fs = require('fs');
 var csv = require('fast-csv');
 var moment = require('moment');
 var PromishLib = require('../utils/promish');
+var StreamBuf = require('../utils/stream-buf');
 
 var utils = require('../utils/utils');
 
@@ -166,5 +167,13 @@ CSV.prototype = {
     var stream = fs.createWriteStream(filename, streamOptions);
 
     return this.write(stream, options);
+  },
+  writeBuffer: function(options) {
+    var self = this;
+    var stream = new StreamBuf();
+    return self.write(stream, options)
+      .then(function() {
+        return stream.read();
+      });
   }
 };

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "underscore": "^1.8.3"
   },
   "main": "./dist/es5/index.js",
+  "types": "./index.d.ts",
   "files": [
     "dist",
     "LICENSE",

--- a/spec/browser/exceljs.spec.js
+++ b/spec/browser/exceljs.spec.js
@@ -66,4 +66,23 @@ describe('ExcelJS', function() {
       })
       .catch(unexpectedError(done));
   });
+  it('should write csv via buffer', function(done) {
+    var wb = new ExcelJS.Workbook();
+    var ws = wb.addWorksheet('blort');
+
+    ws.getCell('A1').value = 'Hello, World!';
+    ws.getCell('B1').value = 'What time is it?';
+    ws.getCell('A2').value = 7;
+    ws.getCell('B2').value = '12pm';
+
+    wb.csv.writeBuffer()
+      .then(function(buffer) {
+        expect(buffer.toString()).toEqual('"Hello, World!",What time is it?\n7,12pm')
+        done();
+      })
+      .catch(function(error) {
+        throw error;
+      })
+      .catch(unexpectedError(done));
+  });
 });


### PR DESCRIPTION
Added csv write buffer support. Update types to include `writeBuffer` and modify types so they can be used for both browser and node installations.