### PR TITLE
Add test case with a huge file

### DIFF
--- a/spec/integration/workbook-xlsx-reader.spec.js
+++ b/spec/integration/workbook-xlsx-reader.spec.js
@@ -37,6 +37,17 @@ describe('WorkbookReader', function() {
           });
       });
 
+      it('should fail fast on a huge file', function() {
+        this.timeout(1000);
+        var workbook = new Excel.Workbook();
+        return workbook.xlsx.readFile('./spec/integration/data/huge.xlsx', {maxRows: 100})
+          .then(function() {
+            throw new Error('Promise unexpectedly fulfilled');
+          }, function(err) {
+            expect(err.message).to.equal('Max row count exceeded');
+          });
+      });
+
       it('should parse fine if the limit is not exceeded', function() {
         var workbook = new Excel.Workbook();
         return workbook.xlsx.readFile('./spec/integration/data/fibonacci.xlsx', {maxRows: 20});


### PR DESCRIPTION
Looks like https://github.com/guyonroche/exceljs/commit/095c82faa238f91c72e4dee92d33939b9c9065f1 broke an essential feature of the [maxRows PR](https://github.com/guyonroche/exceljs/pull/541). It is delaying the [teardown of the stream](https://github.com/peakon/exceljs/blob/1ef6b6026b4eb80bbf4c8790e52638e91c3287ba/lib/xlsx/xform/base-xform.js#L69-L76) to the next tick by moving it to `promise.catch(...)` here: https://github.com/guyonroche/exceljs/commit/095c82faa238f91c72e4dee92d33939b9c9065f1#diff-678e4bd9f1bcf0cc0c17eee7684618abR101

That means that the parser will still busyloop on the remaining rows of the current unzipped chunk, which can be quite a lot.

I've added a test with a huge .xlsx that runs for over 30 seconds on my machine, but less than a second when I revert the tidy commit.

I'm not sure exactly how to fix it without essentially reverting most of it, so for now I'm just submitting the test :)