### PR TITLE
core-xform: Tolerate a missing cp: namespace for the coreProperties element

### DIFF
--- a/lib/xlsx/xform/core/core-xform.js
+++ b/lib/xlsx/xform/core/core-xform.js
@@ -79,6 +79,7 @@ utils.inherits(CoreXform, BaseXform, {
     }
     switch (node.name) {
       case 'cp:coreProperties':
+      case 'coreProperties':
         return true;
       default:
         this.parser = this.map[node.name];
@@ -103,6 +104,7 @@ utils.inherits(CoreXform, BaseXform, {
     }
     switch (name) {
       case 'cp:coreProperties':
+      case 'coreProperties':
         this.model = {
           creator: this.map['dc:creator'].model,
           title: this.map['dc:title'].model,

--- a/spec/unit/xlsx/xform/core/core-xform.spec.js
+++ b/spec/unit/xlsx/xform/core/core-xform.spec.js
@@ -55,6 +55,13 @@ var expectations = [
     parsedModel: {title: '...', creator: '...', lastModifiedBy: '...', lastPrinted: new Date('2017-05-15T16:17:00Z'), created: new Date('2015-07-15T16:27:34Z'), modified: new Date('2017-09-06T15:39:12Z')},
     tests: ['parse']
   },
+  {
+    title: 'core.xml - without namespace for coreProperties node',
+    create: () => new CoreXform(),
+    xml: fs.readFileSync(__dirname + '/data/core.06.xml').toString().replace(/\r\n/g, '\n'),
+    parsedModel: {creator: 'Apache POI', created: new Date('2018-05-08T14:56:50Z')},
+    tests: ['parse']
+  },
 ];
 
 describe('CoreXform', function() {

--- a/spec/unit/xlsx/xform/core/data/core.06.xml
+++ b/spec/unit/xlsx/xform/core/data/core.06.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<coreProperties xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dcterms:created xsi:type="dcterms:W3CDTF">2018-05-08T14:56:50Z</dcterms:created>
+  <dc:creator>Apache POI</dc:creator>
+</coreProperties>


### PR DESCRIPTION
I ran into a weird spreadsheet that claims it was generated by [Apache POI](https://poi.apache.org/). It is missing the `cp:` namespace for the `<cp:coreProperties>` element:

```xml
<?xml version="1.0" encoding="UTF-8"?>

<coreProperties xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <dcterms:created xsi:type="dcterms:W3CDTF">2018-05-08T14:56:50Z</dcterms:created>
  <dc:creator>Apache POI</dc:creator>
</coreProperties>
```

which makes exceljs die with:

```
Error: Unexpected xml node in parseClose: coreProperties
    at module.exports.parseClose (/Users/andreaslind/work/exceljs/lib/xlsx/xform/core/core-xform.js:126:15)
    at SAXStream.<anonymous> (/Users/andreaslind/work/exceljs/lib/xlsx/xform/base-xform.js:87:21)
    at SAXStream.emit (events.js:160:13)
    at SAXParser.me._parser.(anonymous function) [as onclosetag] (/Users/andreaslind/work/exceljs/node_modules/sax/lib/sax.js:258:17)
    at emit (/Users/andreaslind/work/exceljs/node_modules/sax/lib/sax.js:624:35)
    at emitNode (/Users/andreaslind/work/exceljs/node_modules/sax/lib/sax.js:629:5)
    at closeTag (/Users/andreaslind/work/exceljs/node_modules/sax/lib/sax.js:889:7)
    at SAXParser.write (/Users/andreaslind/work/exceljs/node_modules/sax/lib/sax.js:1436:13)
    at SAXStream.write (/Users/andreaslind/work/exceljs/node_modules/sax/lib/sax.js:239:18)
    at /Users/andreaslind/work/exceljs/lib/utils/stream-buf.js:195:14
```

The enclosed fix tolerates the missing namespace so the metadata is parsed.