### PR TITLE
Avoid error on malformed address

### DIFF
--- a/lib/utils/col-cache.js
+++ b/lib/utils/col-cache.js
@@ -89,20 +89,29 @@ var colCache = module.exports = {
     if (addr) {
       return addr;
     }
-
-    var col = value.match(/[A-Z]+/)[0];
-    var colNumber = this.l2n(col);
-    var row = value.match(/\d+/)[0];
-    var rowNumber = parseInt(row, 10);
+    var matchCol = value.match(/[A-Z]+/);
+    var col;
+    var colNumber;
+    if (matchCol) {
+      col = matchCol[0];
+      colNumber = this.l2n(col);
+    }
+    var matchRow = value.match(/\d+/);
+    var row;
+    var rowNumber;
+    if (matchRow) {
+      row = matchRow[0];
+      rowNumber = parseInt(row, 10);
+    }
 
     // in case $row$col
-    value = col + row;
+    value = (col || '') + (row || '');
 
     var address = {
       address: value,
       col: colNumber,
       row: rowNumber,
-      $col$row: '$' + col + '$' + row
+      $col$row: '$' + (col || '') + '$' + (row || '')
     };
 
     // mem fix - cache only the tl 100x100 square

--- a/spec/unit/utils/col-cache.spec.js
+++ b/spec/unit/utils/col-cache.spec.js
@@ -66,13 +66,13 @@ describe('colCache', function() {
   it('decodes addresses', function() {
     expect(colCache.decodeAddress('A1')).to.deep.equal({address: 'A1', col: 1, row: 1, $col$row: '$A$1'});
     expect(colCache.decodeAddress('AA11')).to.deep.equal({address: 'AA11', col: 27, row: 11, $col$row: '$AA$11'});
+  });
 
-    it('convert [sheetName!][$]col[$]row[[$]col[$]row] into address or range structures', function() {
-      expect(colCache.decodeEx('Sheet1!$H$1')).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet1'});
-      expect(colCache.decodeEx("'Sheet 1'!$H$1")).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet 1'});
-      expect(colCache.decodeEx("'Sheet !$:1'!$H$1")).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet !$:1'});
-      expect(colCache.decodeEx("'Sheet !$:1'!#REF!")).to.deep.equal({sheetName: 'Sheet !$:1', error: '#REF!'});
-    });
+  it('convert [sheetName!][$]col[$]row[[$]col[$]row] into address or range structures', function() {
+    expect(colCache.decodeEx('Sheet1!$H$1')).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet1'});
+    expect(colCache.decodeEx("'Sheet 1'!$H$1")).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet 1'});
+    expect(colCache.decodeEx("'Sheet !$:1'!$H$1")).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet !$:1'});
+    expect(colCache.decodeEx("'Sheet !$:1'!#REF!")).to.deep.equal({sheetName: 'Sheet !$:1', error: '#REF!'});
   });
 
   it('gets address structures (and caches them)', function() {

--- a/spec/unit/utils/col-cache.spec.js
+++ b/spec/unit/utils/col-cache.spec.js
@@ -68,6 +68,16 @@ describe('colCache', function() {
     expect(colCache.decodeAddress('AA11')).to.deep.equal({address: 'AA11', col: 27, row: 11, $col$row: '$AA$11'});
   });
 
+  describe('with a malformed address', function() {
+    it('tolerates a missing row number', function() {
+      expect(colCache.decodeAddress('$B')).to.deep.equal({address: 'B', col: 2, row: undefined, $col$row: '$B$'});
+    });
+
+    it('tolerates a missing column number', function() {
+      expect(colCache.decodeAddress('$2')).to.deep.equal({address: '2', col: undefined, row: 2, $col$row: '$$2'});
+    });
+  });
+
   it('convert [sheetName!][$]col[$]row[[$]col[$]row] into address or range structures', function() {
     expect(colCache.decodeEx('Sheet1!$H$1')).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet1'});
     expect(colCache.decodeEx("'Sheet 1'!$H$1")).to.deep.equal({$col$row: '$H$1', address: 'H1', col: 8, row: 1, sheetName: 'Sheet 1'});


### PR DESCRIPTION
Hi, I've run into another weird Excel file that causes an error in exceljs:

```
TypeError: Cannot read property '0' of null
    at Object.decodeAddress (/Users/andreaslind/work/exceljs/lib/utils/col-cache.js:95:33)
    at Object.decodeEx (/Users/andreaslind/work/exceljs/lib/utils/col-cache.js:156:21)
    at /Users/andreaslind/work/exceljs/lib/xlsx/xform/book/workbook-xform.js:182:34
    at Array.forEach (<anonymous>)
    at Object.each (/Users/andreaslind/work/exceljs/lib/utils/under-dash.js:7:13)
    at module.exports.reconcile (/Users/andreaslind/work/exceljs/lib/xlsx/xform/book/workbook-xform.js:175:7)
    at module.exports.reconcile (/Users/andreaslind/work/exceljs/lib/xlsx/xlsx.js:91:19)
    at /Users/andreaslind/work/exceljs/lib/xlsx/xlsx.js:345:16
    at <anonymous>
```

The error is triggered by this `xl/workbook.xml` (slightly edited and pretty-printed):

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr6="http://schemas.microsoft.com/office/spreadsheetml/2016/revision6" xmlns:xr10="http://schemas.microsoft.com/office/spreadsheetml/2016/revision10" xmlns:xr2="http://schemas.microsoft.com/office/spreadsheetml/2015/revision2" mc:Ignorable="x15 xr xr6 xr10 xr2">
  <fileVersion appName="xl" lastEdited="7" lowestEdited="6" rupBuild="10311"/>
  <workbookPr/>
  <xr:revisionPtr revIDLastSave="0" documentId="13_ncr:1_{C8FC9E1B-96BE-724A-A363-02D52AD78D60}" xr6:coauthVersionLast="31" xr6:coauthVersionMax="32" xr10:uidLastSave="{00000000-0000-0000-0000-000000000000}"/>
  <bookViews>
    <workbookView xWindow="260" yWindow="460" windowWidth="28280" windowHeight="15860" tabRatio="500" xr2:uid="{00000000-000D-0000-FFFF-FFFF00000000}"/>
  </bookViews>
  <sheets>
    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
  </sheets>
  <definedNames>
    <definedName name="_xlnm._FilterDatabase" localSheetId="0" hidden="1">Sheet1!$A$1:$V$121</definedName>
    <definedName name="_xlnm.Print_Area" localSheetId="0">Sheet1!$B:$F</definedName>
  </definedNames>
  <calcPr calcId="179017" concurrentCalc="0"/>
</workbook>
```

Specifically `Sheet1!$B:$F`. The fragments are passed to `colCache.decodeAddress`, which assumes that there's a row number in each of the references (`$B` and `$F`). I can't tell if this syntax is legal or not -- I don't really know much about the .xlsx file format.

I tried to create a spec that triggers the error, but it seems that basing it off 
scenarios in https://github.com/guyonroche/exceljs/blob/master/spec/unit/xlsx/xform/book/workbook-xform.spec.js doesn't work as that does not exercise the reconciliation phase.

The enclosed change avoids the error by making `decodeAddress` do a "best effort" when handed this kind of weird reference. I honestly don't know if that is the right way to go about it.

Unfortunately, I'm unable to share the original .xlsx file that triggered the error.