### PR TITLE
Added a missing Promise<void> in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1334,7 +1334,7 @@ export namespace stream {
 		class WorkbookWriter extends Workbook {
 			constructor(options: Partial<WorkbookWriterOptions>);
 			// commit all worksheets, then add suplimentary files
-			commit(): void;
+			commit(): Promise<void>;
 			addStyles(): Promise<void>;
 			addThemes(): Promise<void>;
 			addOfficeRels(): Promise<void>;


### PR DESCRIPTION
In response from #548:
Fixed a typo in index.d.ts where stream.xlsx.workbook.commit()  is said to return void rather than Promise<void> as it does in the code and doc.

(I believe it could also be marked as returning Promise<WorkbookWriter> but I'm not fluent enough with Promish to state that with certainty.
As the documentation currently does not talk about return value beyond the promise, I believe that's a question for another day...)