### PR TITLE
Fix some xlsx stream read xlsx not in guaranteed order problem

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -21,6 +21,8 @@ var WorkbookPropertiesManager = require('../../xlsx/xform/book/workbook-properti
 var WorksheetReader = require('./worksheet-reader');
 var HyperlinkReader = require('./hyperlink-reader');
 
+var Temp = require('temp');
+
 var WorkbookReader = module.exports = function(options) {
   this.options = options = options || {};
 
@@ -40,6 +42,9 @@ var WorkbookReader = module.exports = function(options) {
 
   // end of stream check
   this.atEnd = false;
+
+  Temp.track();
+  this.waitingWorkSheets = [];
 };
 
 utils.inherits(WorkbookReader, events.EventEmitter, {
@@ -91,7 +96,13 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
           if (entry.path.match(/xl\/worksheets\/sheet\d+[.]xml/)) {
             match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
             sheetNo = match[1];
-            this._parseWorksheet(entry, sheetNo, options);
+            if (this.sharedStrings) {
+              this._parseWorksheet(entry, sheetNo, options);
+            } else {
+              var stream = Temp.createWriteStream();
+              this.waitingWorkSheets.push({sheetNo: sheetNo, options: options, path: stream.path});
+              entry.pipe(stream);
+            }
           } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
             match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
             sheetNo = match[1];
@@ -104,11 +115,44 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
     });
 
     zip.on('close', () => {
-      this.emit('end');
-      this.atEnd = true;
-      if (!this.readers) {
-        this.emit('finished');
+      if (this.waitingWorkSheets.length) {
+          var currentBook = 0;
+
+          var processBooks = function () {
+              var worksheetInfo = this.waitingWorkSheets[currentBook];
+              var entry = fs.createReadStream(worksheetInfo.path);
+
+              var sheetNo = worksheetInfo.sheetNo;
+              var options = worksheetInfo.options;
+              var worksheet = this._parseWorksheet(entry, sheetNo, options);
+
+              worksheet.on('finished', function (node) {
+                  ++currentBook;
+                  if (currentBook == this.waitingWorkSheets.length) {
+                      Temp.cleanupSync();
+                      // setImmediate(this.emit.bind(this), 'finished');
+
+                      this.emit('end');
+                      this.atEnd = true;
+                      if (!this.readers) {
+                          this.emit('finished');
+                      }
+                  } else {
+                      setImmediate(processBooks);
+                  }
+              })
+              setImmediate(this.emit.bind(this),'worksheet',worksheet);
+          }
+          setImmediate(processBooks);
+      } else {
+          this.emit('end');
+          this.atEnd = true;
+          if (!this.readers) {
+              this.emit('finished');
+          }
       }
+
+      
     });
 
     zip.on('error', err => {
@@ -204,6 +248,7 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
       this.emit('worksheet', worksheetReader);
     }
     worksheetReader.read(entry, options, this.hyperlinkReaders[sheetNo]);
+    return worksheetReader;
   },
   _parseHyperlinks: function(entry, sheetNo, options) {
     this._emitEntry(options, {type: 'hyerlinks', id: sheetNo});

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -136,7 +136,7 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
 
                       self.emit('end');
                       self.atEnd = true;
-                      if (!this.readers) {
+                      if (!self.readers) {
                           self.emit('finished');
                       }
                   } else {

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -78,6 +78,7 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
 
     zip.on('entry', entry => {
       var match, sheetNo;
+      // console.log(entry.path);
       switch (entry.path) {
         case '_rels/.rels':
         case 'xl/_rels/workbook.xml.rels':
@@ -115,33 +116,33 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
     });
 
     zip.on('close', () => {
+      var self = this;
       if (this.waitingWorkSheets.length) {
           var currentBook = 0;
 
           var processBooks = function () {
-              var worksheetInfo = this.waitingWorkSheets[currentBook];
+              var worksheetInfo = self.waitingWorkSheets[currentBook];
               var entry = fs.createReadStream(worksheetInfo.path);
 
               var sheetNo = worksheetInfo.sheetNo;
               var options = worksheetInfo.options;
-              var worksheet = this._parseWorksheet(entry, sheetNo, options);
+              var worksheet = self._parseWorksheet(entry, sheetNo, options);
 
               worksheet.on('finished', function (node) {
                   ++currentBook;
-                  if (currentBook == this.waitingWorkSheets.length) {
+                  if (currentBook == self.waitingWorkSheets.length) {
                       Temp.cleanupSync();
                       // setImmediate(this.emit.bind(this), 'finished');
 
-                      this.emit('end');
-                      this.atEnd = true;
+                      self.emit('end');
+                      self.atEnd = true;
                       if (!this.readers) {
-                          this.emit('finished');
+                          self.emit('finished');
                       }
                   } else {
                       setImmediate(processBooks);
                   }
               })
-              setImmediate(this.emit.bind(this),'worksheet',worksheet);
           }
           setImmediate(processBooks);
       } else {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "moment": ">=2.19.3",
     "node-unzip-2": "^0.2.7",
     "promish": ">=5.0.2",
-    "sax": "^1.2.2"
+    "sax": "^1.2.2",
+    "temp": "0.8.3"
   },
   "devDependencies": {
     "@types/node": "*",


### PR DESCRIPTION
when stream read some xlsx files (like numbers convert to xlsx),  get values like :
row.values [ ,
  { sharedString: 47 },
  { sharedString: 35 },
  { sharedString: 47 },
  { sharedString: 37 },
  { sharedString: 37 },
  { sharedString: 37 },
  { sharedString: 37 },
  { sharedString: 37 },
  { sharedString: 37 },
]

try to fix this problem
