### PR TITLE
drawing element must be below rowBreaks according to spec or corrupt worksheet

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -182,9 +182,9 @@ utils.inherits(WorkSheetXform, BaseXform, {
     this.map.pageMargins.render(xmlStream, pageMarginsModel);
     this.map.printOptions.render(xmlStream, printOptionsModel);
     this.map.pageSetup.render(xmlStream, model.pageSetup);
-    this.map.picture.render(xmlStream, model.background); // Note: must be after drawing
     this.map.rowBreaks.render(xmlStream, model.rowBreaks);
-    this.map.drawing.render(xmlStream, model.drawing);
+    this.map.drawing.render(xmlStream, model.drawing); // Note: must be after rowBreaks
+    this.map.picture.render(xmlStream, model.background); // Note: must be after drawing
 
     xmlStream.closeNode();
   },

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -182,9 +182,9 @@ utils.inherits(WorkSheetXform, BaseXform, {
     this.map.pageMargins.render(xmlStream, pageMarginsModel);
     this.map.printOptions.render(xmlStream, printOptionsModel);
     this.map.pageSetup.render(xmlStream, model.pageSetup);
-    this.map.drawing.render(xmlStream, model.drawing);
     this.map.picture.render(xmlStream, model.background); // Note: must be after drawing
     this.map.rowBreaks.render(xmlStream, model.rowBreaks);
+	  this.map.drawing.render(xmlStream, model.drawing);
 
     xmlStream.closeNode();
   },

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -182,9 +182,10 @@ utils.inherits(WorkSheetXform, BaseXform, {
     this.map.pageMargins.render(xmlStream, pageMarginsModel);
     this.map.printOptions.render(xmlStream, printOptionsModel);
     this.map.pageSetup.render(xmlStream, model.pageSetup);
+    this.map.drawing.render(xmlStream, model.drawing);
     this.map.picture.render(xmlStream, model.background); // Note: must be after drawing
     this.map.rowBreaks.render(xmlStream, model.rowBreaks);
-	  this.map.drawing.render(xmlStream, model.drawing);
+    this.map.drawing.render(xmlStream, model.drawing);
 
     xmlStream.closeNode();
   },

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -182,7 +182,6 @@ utils.inherits(WorkSheetXform, BaseXform, {
     this.map.pageMargins.render(xmlStream, pageMarginsModel);
     this.map.printOptions.render(xmlStream, printOptionsModel);
     this.map.pageSetup.render(xmlStream, model.pageSetup);
-    this.map.drawing.render(xmlStream, model.drawing);
     this.map.picture.render(xmlStream, model.background); // Note: must be after drawing
     this.map.rowBreaks.render(xmlStream, model.rowBreaks);
     this.map.drawing.render(xmlStream, model.drawing);


### PR DESCRIPTION
I had an issue with adding both images and a pagebreak to a worksheet. Adding them independently was fine but adding them both together result in a corrupt document. 

The issue was related to the ordering of the elements. drawing must be below rowBreaks as seen here:

https://stackoverflow.com/a/12221477/4564456

You can also see the ordering of all the other elements there in case this comes up with new features. Moving drawing and picture below rowBreaks fixes the issue.

I'm currently blocked until this is merged so please let me know if there's anything else I can do to help! :)

Thanks