### PR TITLE
Ability to set tooltip for hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,11 @@ A URL with both text and link value.
 E.g.
 ```javascript
 // link to web
-worksheet.getCell('A1').value = { text: 'www.mylink.com', hyperlink: 'http://www.mylink.com' };
+worksheet.getCell('A1').value = {
+  text: 'www.mylink.com',
+  hyperlink: 'http://www.mylink.com',
+  tooltip: 'www.mylink.com'
+};
 
 // internal link
 worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\\"Sheet2\\"!A1' };
@@ -1849,4 +1853,3 @@ If any splice operation affects a merged cell, the merge group will not be moved
 | 1.4.12  | <ul> <li> Merged <a href="https://github.com/guyonroche/exceljs/pull/567">Avoid error on malformed address #567</a>. Many thanks to <a href="https://github.com/papandreou">Andreas Lind</a> for this contribution. </li> <li> Merged <a href="https://github.com/guyonroche/exceljs/pull/571">Added a missing Promise&lt;void&gt; in index.d.ts #571</a>. Many thanks to <a href="https://github.com/carboneater">Gabriel Fournier</a> for this contribution. This release should fix <a href="https://github.com/guyonroche/exceljs/issues/548">Is workbook.commit() still a promise or not #548</a> </li> </ul> |
 | 1.4.13  | <ul> <li> Merged <a href="https://github.com/guyonroche/exceljs/pull/574">Issue #488 #574</a>. Many thanks to <a href="https://github.com/dljenkins">dljenkins</a> for this contribution. This release should fix <a href="https://github.com/guyonroche/exceljs/issues/488">Invalid time value Exception #488</a>. </li> </ul> |
 | 1.5.0   | <ul> <li> Merged <a href="https://github.com/guyonroche/exceljs/pull/577">Sheet add state for hidden or show #577</a>. Many thanks to <a href="https://github.com/Hsinfu">Freddie Hsinfu Huang</a> for this contribution. This release should fix <a href="https://github.com/guyonroche/exceljs/issues/226">hide worksheet and reorder sheets #226</a>. </li> </ul> |
-

--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -488,6 +488,7 @@ var HyperlinkValue = function(cell, value) {
     address: cell.address,
     type: Cell.Types.Hyperlink,
     text: value ? value.text : undefined,
+    tooltip: value && value.tooltip ? value.tooltip : undefined,
     hyperlink: value ? value.hyperlink : undefined
   };
 };
@@ -495,11 +496,13 @@ HyperlinkValue.prototype = {
   get value() {
     return {
       text: this.model.text,
+      tooltip: this.model.tooltip,
       hyperlink: this.model.hyperlink
     };
   },
   set value(value) {
     this.model.text = value.text;
+    this.model.tooltip = value.tooltip;
     this.model.hyperlink = value.hyperlink;
   },
 

--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -484,40 +484,38 @@ DateValue.prototype = {
 };
 
 var HyperlinkValue = function(cell, value) {
-  this.model = {
+  this.model = Object.assign({
     address: cell.address,
     type: Cell.Types.Hyperlink,
     text: value ? value.text : undefined,
-    tooltip: value && value.tooltip ? value.tooltip : undefined,
     hyperlink: value ? value.hyperlink : undefined
-  };
+  }, value && value.tooltip ? {tooltip: value.tooltip} : {});
 };
 HyperlinkValue.prototype = {
   get value() {
-    return {
+    return Object.assign({
       text: this.model.text,
-      tooltip: this.model.tooltip,
       hyperlink: this.model.hyperlink
-    };
+    }, this.model.tooltip ? {tooltip: this.model.tooltip} : {});
   },
   set value(value) {
-    this.model.text = value.text;
-    this.model.tooltip = value.tooltip;
-    this.model.hyperlink = value.hyperlink;
+    this.model = Object.assign({
+      text: value.text,
+      hyperlink: value.hyperlink
+    }, value && value.tooltip ? {tooltip: value.tooltip} : {});
   },
-
   get text() {
     return this.model.text;
   },
   set text(value) {
     this.model.text = value;
-  },
+  },/*
   get tooltip() {
     return this.model.tooltip;
   },
   set tooltip(value) {
     this.model.tooltip = value;
-  },
+  },*/
   get hyperlink() {
     return this.model.hyperlink;
   },

--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -512,6 +512,12 @@ HyperlinkValue.prototype = {
   set text(value) {
     this.model.text = value;
   },
+  get tooltip() {
+    return this.model.tooltip;
+  },
+  set tooltip(value) {
+    this.model.tooltip = value;
+  },
   get hyperlink() {
     return this.model.hyperlink;
   },

--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -74,11 +74,10 @@ utils.inherits(CellXform, BaseXform, {
         if (options.sharedStrings) {
           model.ssId = options.sharedStrings.add(model.text);
         }
-        options.hyperlinks.push({
+        options.hyperlinks.push(Object.assign({
           address: model.address,
-          target: model.hyperlink,
-          tooltip: model.tooltip
-        });
+          target: model.hyperlink
+        }, model.tooltip ? {tooltip: model.tooltip} : {}));
         break;
       case Enums.ValueType.Merge:
         options.merges.add(model);

--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -76,7 +76,8 @@ utils.inherits(CellXform, BaseXform, {
         }
         options.hyperlinks.push({
           address: model.address,
-          target: model.hyperlink
+          target: model.hyperlink,
+          tooltip: model.tooltip
         });
         break;
       case Enums.ValueType.Merge:

--- a/lib/xlsx/xform/sheet/hyperlink-xform.js
+++ b/lib/xlsx/xform/sheet/hyperlink-xform.js
@@ -17,20 +17,18 @@ utils.inherits(HyperlinkXform, BaseXform, {
   get tag() { return 'hyperlink'; },
 
   render: function(xmlStream, model) {
-    xmlStream.leafNode('hyperlink', {
+    xmlStream.leafNode('hyperlink', Object.assign({
       ref: model.address,
       'r:id': model.rId,
-      tooltip: model.tooltip
-    });
+    }, model.tooltip ? {tooltip: model.tooltip} : {}));
   },
 
   parseOpen: function(node) {
     if (node.name === 'hyperlink') {
-      this.model = {
+      this.model = Object.assign({
         address: node.attributes.ref,
         rId: node.attributes['r:id'],
-        tooltip: node.attributes.tooltip
-      };
+      }, node.attributes.tooltip ? {tooltip: node.attributes.tooltip} : {});
       return true;
     }
     return false;

--- a/lib/xlsx/xform/sheet/hyperlink-xform.js
+++ b/lib/xlsx/xform/sheet/hyperlink-xform.js
@@ -19,15 +19,17 @@ utils.inherits(HyperlinkXform, BaseXform, {
   render: function(xmlStream, model) {
     xmlStream.leafNode('hyperlink', {
       ref: model.address,
-      'r:id': model.rId
+      'r:id': model.rId,
+      tooltip: model.tooltip
     });
   },
-  
+
   parseOpen: function(node) {
     if (node.name === 'hyperlink') {
       this.model = {
         address: node.attributes.ref,
-        rId: node.attributes['r:id']
+        rId: node.attributes['r:id'],
+        tooltip: node.attributes.tooltip
       };
       return true;
     }


### PR DESCRIPTION
Hail! 

In MS Excel it is possible to [set a screen tip](https://www.addictivetips.com/microsoft-office/set-custom-hyperlink-tool-tip-text-in-ms-excel/) for a hyperlink. Pull-request adds a similar capability to ExcelJS.

Thanks!