### PR TITLE
Avoid memory leaks when stream gets closed

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -70,6 +70,12 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
   read: function(input, options) {
     var stream = this.stream = this._getStream(input);
     var zip = this.zip = unzip.Parse();
+    
+    stream.on('close', function () {
+        zip.removeAllListeners('entry');
+        zip.removeAllListeners('close');
+        zip.destroy();
+    });
 
     zip.on('entry', entry => {
       var match, sheetNo;


### PR DESCRIPTION
Avoid memory leaks when stream gets closed. We need sometimes parse just small subset of big excel and abort parsing file.
Besides that the analysed heap is full of emitters from low level parsing which are not cleaned up properly after parsing is aborted