### PR TITLE
Avoid zip parsing when stream gets closed

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -76,6 +76,10 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
     var stream = this.stream = this._getStream(input);
     var zip = this.zip = unzip.Parse();
 
+    stream.on('error', () => {
+      zip.destroy();
+    });
+
     zip.on('entry', entry => {
       var match, sheetNo;
       // console.log(entry.path);


### PR DESCRIPTION
If the source stream is dead due some reasons, then no need to continue parsing zip.
Right now in a case of the error, zip is still parsing data even if the source stream is already broken or destroyed which leads to memory leaks and high memory consumption.

We can reproduce this when we interrupt parsing for the big excel files.